### PR TITLE
Add a tool to AOT compile TCP snippets into CPU binaries

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -322,12 +322,29 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "Pipeline",
+    srcs = [
+        "lib/Pipeline/Pipeline.cpp",
+    ],
+    hdrs = [
+        "include/Pipeline/Pipeline.h",
+    ],
+    strip_include_prefix = "include",
+    deps = [
+        ":TcpConversionPasses",
+        "@llvm-project//mlir:ConversionPasses",
+        "@llvm-project//mlir:Pass",
+    ],
+)
+
 cc_binary(
     name = "tcp-opt",
     srcs = [
         "tools/tcp-opt/tcp-opt.cpp",
     ],
     deps = [
+        ":Pipeline",
         ":TcpDialect",
         ":TcpInitAll",
         ":TcpPasses",

--- a/deps.bzl
+++ b/deps.bzl
@@ -66,4 +66,3 @@ def third_party_deps():
         urls = ["https://github.com/google/googletest/archive/f8d7d77c06936315286eb55f8de22cd23c188571.zip"],
         strip_prefix = "googletest-f8d7d77c06936315286eb55f8de22cd23c188571",
     )
-

--- a/deps.bzl
+++ b/deps.bzl
@@ -60,3 +60,10 @@ def third_party_deps():
             "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.0.7.zip",
         ],
     )
+
+    http_archive(
+        name = "googletest",
+        urls = ["https://github.com/google/googletest/archive/f8d7d77c06936315286eb55f8de22cd23c188571.zip"],
+        strip_prefix = "googletest-f8d7d77c06936315286eb55f8de22cd23c188571",
+    )
+

--- a/include/Pipeline/Pipeline.h
+++ b/include/Pipeline/Pipeline.h
@@ -1,0 +1,16 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace mlir {
+namespace tcp {
+void registerTcpPipelines();
+}
+}

--- a/include/Pipeline/Pipeline.h
+++ b/include/Pipeline/Pipeline.h
@@ -13,4 +13,4 @@ namespace mlir {
 namespace tcp {
 void registerTcpPipelines();
 }
-}
+} // namespace mlir

--- a/lib/Pipeline/Pipeline.cpp
+++ b/lib/Pipeline/Pipeline.cpp
@@ -9,8 +9,8 @@
 
 #include "Pipeline/Pipeline.h"
 
-#include "Conversion/TcpToLinalg/TcpToLinalg.h"
 #include "Conversion/TcpToArith/TcpToArith.h"
+#include "Conversion/TcpToLinalg/TcpToLinalg.h"
 
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
@@ -19,8 +19,8 @@
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
-#include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/Transforms/Passes.h"
@@ -35,7 +35,8 @@ static void tcpToLlvmPipelineBuilder(OpPassManager &pm) {
   pm.addPass(func::createFuncBufferizePass());
   pm.addPass(bufferization::createEmptyTensorToAllocTensorPass());
   pm.addNestedPass<func::FuncOp>(tensor::createTensorBufferizePass());
-  pm.addNestedPass<func::FuncOp>(bufferization::createBufferizationBufferizePass());
+  pm.addNestedPass<func::FuncOp>(
+      bufferization::createBufferizationBufferizePass());
   pm.addPass(createLinalgBufferizePass());
   pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
   pm.addPass(createConvertSCFToCFPass());
@@ -52,6 +53,6 @@ static void tcpToLlvmPipelineBuilder(OpPassManager &pm) {
 }
 
 void tcp::registerTcpPipelines() {
-  PassPipelineRegistration<>(
-    "lower-tcp-to-llvm", "Lowers TCP to LLVM", tcpToLlvmPipelineBuilder);
+  PassPipelineRegistration<>("lower-tcp-to-llvm", "Lowers TCP to LLVM",
+                             tcpToLlvmPipelineBuilder);
 }

--- a/lib/Pipeline/Pipeline.cpp
+++ b/lib/Pipeline/Pipeline.cpp
@@ -1,0 +1,57 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Pipeline/Pipeline.h"
+
+#include "Conversion/TcpToLinalg/TcpToLinalg.h"
+#include "Conversion/TcpToArith/TcpToArith.h"
+
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
+#include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
+#include "mlir/Conversion/MathToLibm/MathToLibm.h"
+#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
+#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
+#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
+#include "mlir/Dialect/Func/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Tensor/Transforms/Passes.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+using namespace mlir;
+
+static void tcpToLlvmPipelineBuilder(OpPassManager &pm) {
+  pm.addPass(tcp::createConvertTcpToLinalgPass());
+  pm.addPass(tcp::createConvertTcpToArithPass());
+  pm.addPass(func::createFuncBufferizePass());
+  pm.addPass(bufferization::createEmptyTensorToAllocTensorPass());
+  pm.addNestedPass<func::FuncOp>(tensor::createTensorBufferizePass());
+  pm.addNestedPass<func::FuncOp>(bufferization::createBufferizationBufferizePass());
+  pm.addPass(createLinalgBufferizePass());
+  pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+  pm.addPass(createConvertSCFToCFPass());
+
+  pm.addPass(memref::createExpandStridedMetadataPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addPass(createFinalizeMemRefToLLVMConversionPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addPass(createConvertMathToLibmPass());
+  pm.addPass(createConvertMathToLLVMPass());
+  pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  pm.addPass(createConvertFuncToLLVMPass());
+  pm.addPass(createReconcileUnrealizedCastsPass());
+}
+
+void tcp::registerTcpPipelines() {
+  PassPipelineRegistration<>(
+    "lower-tcp-to-llvm", "Lowers TCP to LLVM", tcpToLlvmPipelineBuilder);
+}

--- a/test/BUILD
+++ b/test/BUILD
@@ -42,7 +42,10 @@ filegroup(
             "//test:lit_data",
         ],
     )
-    for src in glob(["Conversion/**/*.mlir", "Dialect/**/*.mlir"])
+    for src in glob([
+        "Conversion/**/*.mlir",
+        "Dialect/**/*.mlir",
+    ])
 ]
 
 aot_compile(
@@ -52,10 +55,10 @@ aot_compile(
 
 cc_test(
     name = "test_aot_compiled_basic_tcp_ops",
+    srcs = ["test_aot_compiled_basic_tcp_ops.cpp"],
     deps = [
         ":aot_compiled_basic_tcp_ops",
         "//tools/aot:abi",
-        "@googletest//:gtest_main"
+        "@googletest//:gtest_main",
     ],
-    srcs = ["test_aot_compiled_basic_tcp_ops.cpp"]
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -42,10 +42,13 @@ filegroup(
             "//test:lit_data",
         ],
     )
-    for src in glob(["**/*.mlir"])
+    for src in glob(["Conversion/**/*.mlir", "Dialect/**/*.mlir"])
 ]
 
-aot_compile("basic_tcp_ops", "basic_tcp_ops.mlir")
+aot_compile(
+    name = "basic_tcp_ops",
+    tcp_source = "basic_tcp_ops.mlir",
+)
 
 cc_test(
     name = "test_aot_compiled_basic_tcp_ops",

--- a/test/BUILD
+++ b/test/BUILD
@@ -5,6 +5,7 @@
 
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@llvm-project//llvm:lit_test.bzl", "lit_test")
+load("@//tools/aot:aot_compile.bzl", "aot_compile")
 
 expand_template(
     name = "lit_site_cfg_py",
@@ -43,3 +44,15 @@ filegroup(
     )
     for src in glob(["**/*.mlir"])
 ]
+
+aot_compile("basic_tcp_ops", "basic_tcp_ops.mlir")
+
+cc_test(
+    name = "test_aot_compiled_basic_tcp_ops",
+    deps = [
+        ":aot_compiled_basic_tcp_ops",
+        "//tools/aot:abi",
+        "@googletest//:gtest_main"
+    ],
+    srcs = ["test_aot_compiled_basic_tcp_ops.cpp"]
+)

--- a/test/basic_tcp_ops.mlir
+++ b/test/basic_tcp_ops.mlir
@@ -1,0 +1,25 @@
+func.func @func_1(%arg0: tensor<?x?xf32>,
+                  %arg1: tensor<?x?xf32>,
+                  %arg2: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  %1 = tcp.mul %0, %arg2 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+
+func.func @func_2(%arg0: tensor<?x?xf32>,
+                  %arg1: tensor<?x?xf32>,
+                  %arg2: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+  %0 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  %1 = tcp.mul %0, %arg2 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0, %1 : tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+func.func @func_3(%arg0: tensor<f32>,
+                  %arg1: tensor<?xf32>) -> tensor<?xf32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg1, %c0 : tensor<?xf32>
+  %arg0_ex = tensor.expand_shape %arg0 [] : tensor<f32> into tensor<1xf32>
+  %arg0_bcast = tcp.broadcast %arg0_ex, %dim {axes = [0]} : tensor<1xf32>, index -> tensor<?xf32>
+  %0 = tcp.add %arg0_bcast, %arg1 : tensor<?xf32>, tensor<?xf32> -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}

--- a/test/test_aot_compiled_basic_tcp_ops.cpp
+++ b/test/test_aot_compiled_basic_tcp_ops.cpp
@@ -1,0 +1,125 @@
+#include "tools/aot/abi.h"
+
+#include "gtest/gtest.h"
+
+using namespace mlir::tcp;
+
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+
+extern "C" RankedMemref<float, 2> func_1(DECL_RANK_2_MEMREF_ABI(float),
+                                         DECL_RANK_2_MEMREF_ABI(float),
+                                         DECL_RANK_2_MEMREF_ABI(float));
+
+static RankedMemref<float, 2> CreateRank2Memref(float *Ptr) {
+  RankedMemref<float, 2> Result;
+  Result.AllocatedPointer = Ptr;
+  Result.AlignedPointer = Ptr;
+  Result.Offset = 0;
+  Result.Sizes[0] = 2;
+  Result.Sizes[1] = 3;
+  Result.Strides[0] = 3;
+  Result.Strides[1] = 1;
+
+  return Result;
+}
+
+TEST(AotCompiled, SingleOutput) {
+  float Arr1[2][3];
+  float Arr2[2][3];
+  float Arr3[2][3];
+
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 3; j++) {
+      Arr1[i][j] = 5;
+      Arr2[i][j] = 2 + i;
+      Arr3[i][j] = 3 + j;
+    }
+
+  RankedMemref<float, 2> Input1 = CreateRank2Memref(&Arr1[0][0]);
+  RankedMemref<float, 2> Input2 = CreateRank2Memref(&Arr2[0][0]);
+  RankedMemref<float, 2> Input3 = CreateRank2Memref(&Arr3[0][0]);
+
+  RankedMemref<float, 2> Result =
+      func_1(PASS_RANK_2_MEMREF(Input1), PASS_RANK_2_MEMREF(Input2),
+             PASS_RANK_2_MEMREF(Input3));
+
+  ASSERT_EQ(Result.Sizes[0], 2);
+  ASSERT_EQ(Result.Sizes[1], 3);
+  ASSERT_EQ(Result.Strides[0], 3);
+  ASSERT_EQ(Result.Strides[1], 1);
+
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 3; j++) {
+      float Expected = (5 + (2 + i)) * (3 + j);
+      EXPECT_EQ(Result.AlignedPointer[3 * i + j], Expected);
+    }
+
+  free(Result.AllocatedPointer);
+}
+
+struct TwoMemRefs {
+  RankedMemref<float, 2> A;
+  RankedMemref<float, 2> B;
+};
+
+extern "C" TwoMemRefs func_2(DECL_RANK_2_MEMREF_ABI(float),
+                             DECL_RANK_2_MEMREF_ABI(float),
+                             DECL_RANK_2_MEMREF_ABI(float));
+
+TEST(AotCompiled, MultiOutput) {
+  float Arr1[2][3];
+  float Arr2[2][3];
+  float Arr3[2][3];
+
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 3; j++) {
+      Arr1[i][j] = 5;
+      Arr2[i][j] = 2 + i;
+      Arr3[i][j] = 3 + j;
+    }
+
+  RankedMemref<float, 2> Input1 = CreateRank2Memref(&Arr1[0][0]);
+  RankedMemref<float, 2> Input2 = CreateRank2Memref(&Arr2[0][0]);
+  RankedMemref<float, 2> Input3 = CreateRank2Memref(&Arr3[0][0]);
+
+  TwoMemRefs Result =
+      func_2(PASS_RANK_2_MEMREF(Input1), PASS_RANK_2_MEMREF(Input2),
+             PASS_RANK_2_MEMREF(Input3));
+
+  ASSERT_EQ(Result.A.Sizes[0], 2);
+  ASSERT_EQ(Result.A.Sizes[1], 3);
+  ASSERT_EQ(Result.A.Strides[0], 3);
+  ASSERT_EQ(Result.A.Strides[1], 1);
+
+  ASSERT_EQ(Result.B.Sizes[0], 2);
+  ASSERT_EQ(Result.B.Sizes[1], 3);
+  ASSERT_EQ(Result.B.Strides[0], 3);
+  ASSERT_EQ(Result.B.Strides[1], 1);
+
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 3; j++) {
+      float ExpectedA = 5 + (2 + i);
+      EXPECT_EQ(Result.A.AlignedPointer[3 * i + j], ExpectedA);
+
+      float ExpectedB = ExpectedA * (3 + j);
+      EXPECT_EQ(Result.B.AlignedPointer[3 * i + j], ExpectedB);
+    }
+
+  free(Result.A.AllocatedPointer);
+  free(Result.B.AllocatedPointer);
+}
+
+extern "C" RankedMemref<float, 1> func_3(DECL_RANK_0_MEMREF_ABI(float),
+                                         DECL_RANK_1_MEMREF_ABI(float));
+
+TEST(AotCompiled, MixedRanks) {
+  float Arr0 = 10.0;
+  float Arr1[2] = {1.0, 2.0};
+
+  RankedMemref<float, 1> Result = func_3(&Arr0, &Arr0, 0, Arr1, Arr1, 0, 2, 1);
+
+  EXPECT_EQ(Result.Sizes[0], 2);
+  EXPECT_EQ(Result.Strides[0], 1);
+  EXPECT_EQ(Result.AlignedPointer[0], 11.0);
+  EXPECT_EQ(Result.AlignedPointer[1], 12.0);
+}

--- a/tools/aot/BUILD
+++ b/tools/aot/BUILD
@@ -1,0 +1,10 @@
+package(
+    default_visibility = [
+        "//visibility:public",
+    ],
+)
+
+cc_library(
+    name = "abi",
+    hdrs = ["abi.h"],
+)

--- a/tools/aot/abi.h
+++ b/tools/aot/abi.h
@@ -1,0 +1,60 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace mlir {
+namespace tcp {
+using IndexTy = long;
+
+// An MLIR function with type
+//
+//   (tensor<?xf32>, tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?x?xf32>)
+//
+// Will have the ABI:
+//
+//   Output func(DECL_RANK_1_MEMREF_ABI(float), DECL_RANK_2_MEMREF_ABI(float))
+//
+// where Output is defined as:
+//
+// struct Output {
+//   RankedMemref<float, 2> A;
+//   RankedMemref<float, 3> B;
+// };
+
+template <typename DataType, int Rank> struct RankedMemref {
+  // Described at https://mlir.llvm.org/docs/TargetLLVMIR/#ranked-memref-types
+  DataType *AllocatedPointer;
+  DataType *AlignedPointer;
+  IndexTy Offset;
+  IndexTy Sizes[Rank];
+  IndexTy Strides[Rank];
+};
+
+#define DECL_RANK_2_MEMREF_ABI(data_type)                                      \
+  data_type *, data_type *, IndexTy, IndexTy, IndexTy, IndexTy, IndexTy
+#define DECL_RANK_1_MEMREF_ABI(data_type)                                      \
+  data_type *, data_type *, IndexTy, IndexTy, IndexTy
+#define DECL_RANK_0_MEMREF_ABI(data_type) data_type *, data_type *, IndexTy
+
+// Helper macros that unpack a memref into a sequence of arguments suitable for
+// passing to an AOT compiled function.
+
+#define PASS_RANK_2_MEMREF(memref)                                             \
+  (memref).AllocatedPointer, (memref).AlignedPointer, (memref).Offset,         \
+      (memref).Sizes[0], (memref).Sizes[1], (memref).Strides[0],               \
+      (memref).Strides[1]
+#define PASS_RANK_1_MEMREF(memref)                                             \
+  (memref).AllocatedPointer, (memref).AlignedPointer, (memref).Offset,         \
+      (memref).Sizes[0], (memref).Strides[0],
+#define PASS_RANK_0_MEMREF(memref)                                             \
+  (memref).AllocatedPointer, (memref).AlignedPointer, (memref).Offset
+
+} // namespace tcp
+} // namespace mlir

--- a/tools/aot/aot_compile.bzl
+++ b/tools/aot/aot_compile.bzl
@@ -1,0 +1,26 @@
+def aot_compile(name, tcp_source):
+    """
+    AOT compiles `tcp_source` to a CPU library.
+
+    Exposes a target named `aot_compiled_${name}` that has one global function
+    for every function in `tcp_source`.  Each of the functions in `tcp_source`
+    must consume and return tensors.  The ABI of the generated code is exposed
+    in abi.h.
+    """
+    native.genrule(
+        name = "_internal_gen_asm_" + name,
+        srcs = [tcp_source],
+        outs = ["_internal_" + name + ".S"],
+        cmd = "./$(location //:tcp-opt) -lower-tcp-to-llvm $(SRCS) | ./$(location @llvm-project//mlir:mlir-translate) -mlir-to-llvmir | ./$(location @llvm-project//llvm:llc) -O3 > \"$@\"",
+        tools = [
+            "//:tcp-opt",
+            "@llvm-project//mlir:mlir-translate",
+            "@llvm-project//llvm:llc",
+        ],
+    )
+
+    native.cc_library(
+        name = "aot_compiled_" + name,
+        srcs = ["_internal_" + name + ".S"],
+        testonly = True,
+    )

--- a/tools/tcp-opt/tcp-opt.cpp
+++ b/tools/tcp-opt/tcp-opt.cpp
@@ -14,6 +14,8 @@
 
 #include "InitAll.h"
 
+#include "Pipeline/Pipeline.h"
+
 #include "stablehlo/dialect/Register.h"
 
 using namespace mlir;
@@ -28,6 +30,8 @@ int main(int argc, char **argv) {
   mlir::tcp::registerAllDialects(registry);
 
   mlir::stablehlo::registerAllDialects(registry);
+
+  mlir::tcp::registerTcpPipelines();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(
       argc, argv, "MLIR modular optimizer driver\n", registry));


### PR DESCRIPTION
For now I think it will help in writing execution tests.  Longer term we may find other uses for it.

Here are the changes I made:

1. I added a `-lower-tcp-to-llvm` pass pipeline.
2. Created a genrule based macro that invokes `tcp-opt`, `mlir-translate` & `llc` to generate the CPU binary.
3. Added some tests.