### PR TITLE
Consolidate `TcpOpsIncGen` to include attrdef and enum decls/defs

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,11 @@ package(
 
 td_library(
     name = "TcpDialectTdFiles",
-    srcs = glob(["include/mlir-tcp/Dialect/IR/*.td"]),
+    srcs = [
+        "include/mlir-tcp/Dialect/IR/TcpBase.td",
+        "include/mlir-tcp/Dialect/IR/TcpEnums.td",
+        "include/mlir-tcp/Dialect/IR/TcpOps.td",
+    ],
     includes = ["include"],
     deps = [
         "@llvm-project//mlir:OpBaseTdFiles",
@@ -71,8 +75,14 @@ gentbl_cc_library(
 
 cc_library(
     name = "TcpDialect",
-    srcs = glob(["lib/Dialect/IR/*.cpp"]),
-    hdrs = glob(["include/mlir-tcp/Dialect/IR/*.h"]),
+    srcs = [
+        "lib/Dialect/IR/TcpDialect.cpp",
+        "lib/Dialect/IR/TcpOps.cpp",
+    ],
+    hdrs = [
+        "include/mlir-tcp/Dialect/IR/TcpDialect.h",
+        "include/mlir-tcp/Dialect/IR/TcpOps.h",
+    ],
     strip_include_prefix = "include",
     deps = [
         ":TcpOpsIncGen",
@@ -102,11 +112,19 @@ gentbl_cc_library(
 
 cc_library(
     name = "TcpDialectPasses",
-    srcs = glob([
-        "lib/Dialect/Transforms/*.cpp",
-        "lib/Dialect/Transforms/*.h",
-    ]),
-    hdrs = glob(["include/mlir-tcp/Dialect/Transforms/*.h"]),
+    srcs = [
+        "lib/Dialect/Transforms/FuseTcpOpsPass.cpp",
+        "lib/Dialect/Transforms/IsolateGroupOpsPass.cpp",
+        "lib/Dialect/Transforms/PassDetail.h",
+        "lib/Dialect/Transforms/Passes.cpp",
+        "lib/Dialect/Transforms/VerifyTcpBackendContractPass.cpp",
+    ],
+    hdrs = [
+        "include/mlir-tcp/Dialect/Transforms/FuseTcpOpsPass.h",
+        "include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h",
+        "include/mlir-tcp/Dialect/Transforms/Passes.h",
+        "include/mlir-tcp/Dialect/Transforms/VerifyTcpBackendContractPass.h",
+    ],
     strip_include_prefix = "include",
     deps = [
         ":TcpDialect",
@@ -146,12 +164,17 @@ cc_library(
 
 cc_library(
     name = "TorchToTcp",
-    srcs = glob([
-        "lib/Conversion/TorchToTcp/*.h",
-        "lib/Conversion/TorchToTcp/*.cpp",
-        "lib/Conversion/*.h",
-    ]),
-    hdrs = glob(["include/mlir-tcp/Conversion/TorchToTcp/*.h"]),
+    srcs = [
+        "lib/Conversion/PassDetail.h",
+        "lib/Conversion/TorchToTcp/DataMovement.cpp",
+        "lib/Conversion/TorchToTcp/Elementwise.cpp",
+        "lib/Conversion/TorchToTcp/Misc.cpp",
+        "lib/Conversion/TorchToTcp/PopulatePatterns.h",
+        "lib/Conversion/TorchToTcp/TorchToTcp.cpp",
+        "lib/Conversion/TorchToTcp/Utils.cpp",
+        "lib/Conversion/TorchToTcp/Utils.h",
+    ],
+    hdrs = ["include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h"],
     strip_include_prefix = "include",
     deps = [
         ":TcpConversionPassesIncGen",
@@ -184,11 +207,13 @@ cc_library(
 
 cc_library(
     name = "TcpToLinalg",
-    srcs = glob([
-        "lib/Conversion/TcpToLinalg/*.h",
-        "lib/Conversion/TcpToLinalg/*.cpp",
-        "lib/Conversion/*.h",
-    ]),
+    srcs = [
+        "lib/Conversion/PassDetail.h",
+        "lib/Conversion/TcpToLinalg/Elementwise.cpp",
+        "lib/Conversion/TcpToLinalg/Misc.cpp",
+        "lib/Conversion/TcpToLinalg/PopulatePatterns.h",
+        "lib/Conversion/TcpToLinalg/TcpToLinalg.cpp",
+    ],
     hdrs = ["include/mlir-tcp/Conversion/TcpToLinalg/TcpToLinalg.h"],
     strip_include_prefix = "include",
     deps = [

--- a/BUILD
+++ b/BUILD
@@ -12,56 +12,12 @@ package(
 )
 
 td_library(
-    name = "TcpTdFiles",
-    srcs = [
-        "include/mlir-tcp/Dialect/IR/TcpBase.td",
-        "include/mlir-tcp/Dialect/IR/TcpEnums.td",
-        "include/mlir-tcp/Dialect/IR/TcpOps.td",
-    ],
+    name = "TcpDialectTdFiles",
+    srcs = glob(["include/mlir-tcp/Dialect/IR/*.td"]),
     includes = ["include"],
     deps = [
         "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:SideEffectInterfacesTdFiles",
-    ],
-)
-
-gentbl_cc_library(
-    name = "TcpEnumsIncGen",
-    strip_include_prefix = "include",
-    tbl_outs = [
-        (
-            ["-gen-enum-decls"],
-            "include/mlir-tcp/Dialect/IR/TcpEnums.h.inc",
-        ),
-        (
-            ["-gen-enum-defs"],
-            "include/mlir-tcp/Dialect/IR/TcpEnums.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "include/mlir-tcp/Dialect/IR/TcpOps.td",
-    deps = [
-        ":TcpTdFiles",
-    ],
-)
-
-gentbl_cc_library(
-    name = "TcpAttrsIncGen",
-    strip_include_prefix = "include",
-    tbl_outs = [
-        (
-            ["-gen-attrdef-decls"],
-            "include/mlir-tcp/Dialect/IR/TcpAttrs.h.inc",
-        ),
-        (
-            ["-gen-attrdef-defs"],
-            "include/mlir-tcp/Dialect/IR/TcpAttrs.cpp.inc",
-        ),
-    ],
-    tblgen = "@llvm-project//mlir:mlir-tblgen",
-    td_file = "include/mlir-tcp/Dialect/IR/TcpOps.td",
-    deps = [
-        ":TcpTdFiles",
     ],
 )
 
@@ -91,28 +47,34 @@ gentbl_cc_library(
             ],
             "include/mlir-tcp/Dialect/IR/TcpDialect.cpp.inc",
         ),
+        (
+            ["-gen-attrdef-decls"],
+            "include/mlir-tcp/Dialect/IR/TcpAttrs.h.inc",
+        ),
+        (
+            ["-gen-attrdef-defs"],
+            "include/mlir-tcp/Dialect/IR/TcpAttrs.cpp.inc",
+        ),
+        (
+            ["-gen-enum-decls"],
+            "include/mlir-tcp/Dialect/IR/TcpEnums.h.inc",
+        ),
+        (
+            ["-gen-enum-defs"],
+            "include/mlir-tcp/Dialect/IR/TcpEnums.cpp.inc",
+        ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "include/mlir-tcp/Dialect/IR/TcpOps.td",
-    deps = [
-        ":TcpTdFiles",
-    ],
+    deps = [":TcpDialectTdFiles"],
 )
 
 cc_library(
     name = "TcpDialect",
-    srcs = [
-        "lib/Dialect/IR/TcpDialect.cpp",
-        "lib/Dialect/IR/TcpOps.cpp",
-    ],
-    hdrs = [
-        "include/mlir-tcp/Dialect/IR/TcpDialect.h",
-        "include/mlir-tcp/Dialect/IR/TcpOps.h",
-    ],
+    srcs = glob(["lib/Dialect/IR/*.cpp"]),
+    hdrs = glob(["include/mlir-tcp/Dialect/IR/*.h"]),
     strip_include_prefix = "include",
     deps = [
-        ":TcpAttrsIncGen",
-        ":TcpEnumsIncGen",
         ":TcpOpsIncGen",
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",
@@ -121,19 +83,8 @@ cc_library(
     ],
 )
 
-td_library(
-    name = "TcpTransformsPassesTdFiles",
-    srcs = [
-        "include/mlir-tcp/Dialect/Transforms/Passes.td",
-    ],
-    deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
-)
-
 gentbl_cc_library(
-    name = "TcpTransformsPassesIncGen",
+    name = "TcpDialectPassesIncGen",
     strip_include_prefix = "include",
     tbl_outs = [
         (
@@ -144,41 +95,26 @@ gentbl_cc_library(
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "include/mlir-tcp/Dialect/Transforms/Passes.td",
     deps = [
-        ":TcpTransformsPassesTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:PassBaseTdFiles",
     ],
 )
 
 cc_library(
     name = "TcpDialectPasses",
-    srcs = [
-        "lib/Dialect/Transforms/FuseTcpOpsPass.cpp",
-        "lib/Dialect/Transforms/IsolateGroupOpsPass.cpp",
-        "lib/Dialect/Transforms/PassDetail.h",
-        "lib/Dialect/Transforms/Passes.cpp",
-        "lib/Dialect/Transforms/VerifyTcpBackendContractPass.cpp",
-    ],
-    hdrs = [
-        "include/mlir-tcp/Dialect/Transforms/FuseTcpOpsPass.h",
-        "include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h",
-        "include/mlir-tcp/Dialect/Transforms/Passes.h",
-        "include/mlir-tcp/Dialect/Transforms/VerifyTcpBackendContractPass.h",
-    ],
+    srcs = glob([
+        "lib/Dialect/Transforms/*.cpp",
+        "lib/Dialect/Transforms/*.h",
+    ]),
+    hdrs = glob(["include/mlir-tcp/Dialect/Transforms/*.h"]),
     strip_include_prefix = "include",
     deps = [
         ":TcpDialect",
-        ":TcpTransformsPassesIncGen",
+        ":TcpDialectPassesIncGen",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",
     ],
-)
-
-td_library(
-    name = "TcpConversionPassesTdFiles",
-    srcs = [
-        "include/mlir-tcp/Conversion/Passes.td",
-    ],
-    includes = ["include"],
 )
 
 gentbl_cc_library(
@@ -186,28 +122,19 @@ gentbl_cc_library(
     strip_include_prefix = "include",
     tbl_outs = [
         (
-            [
-                "-gen-pass-decls",
-            ],
+            ["-gen-pass-decls"],
             "include/mlir-tcp/Conversion/Passes.h.inc",
         ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "include/mlir-tcp/Conversion/Passes.td",
-    deps = [
-        ":TcpConversionPassesTdFiles",
-        "@llvm-project//mlir:PassBaseTdFiles",
-    ],
+    deps = ["@llvm-project//mlir:PassBaseTdFiles"],
 )
 
 cc_library(
     name = "TcpConversionPasses",
-    srcs = [
-        "lib/Conversion/Passes.cpp",
-    ],
-    hdrs = [
-        "include/mlir-tcp/Conversion/Passes.h",
-    ],
+    srcs = ["lib/Conversion/Passes.cpp"],
+    hdrs = ["include/mlir-tcp/Conversion/Passes.h"],
     strip_include_prefix = "include",
     deps = [
         ":StablehloToTcp",
@@ -220,9 +147,9 @@ cc_library(
 cc_library(
     name = "TorchToTcp",
     srcs = glob([
-        "lib/Conversion/*.h",
         "lib/Conversion/TorchToTcp/*.h",
         "lib/Conversion/TorchToTcp/*.cpp",
+        "lib/Conversion/*.h",
     ]),
     hdrs = glob(["include/mlir-tcp/Conversion/TorchToTcp/*.h"]),
     strip_include_prefix = "include",
@@ -242,9 +169,7 @@ cc_library(
         "lib/Conversion/PassDetail.h",
         "lib/Conversion/StablehloToTcp/StablehloToTcp.cpp",
     ],
-    hdrs = [
-        "include/mlir-tcp/Conversion/StablehloToTcp/StablehloToTcp.h",
-    ],
+    hdrs = ["include/mlir-tcp/Conversion/StablehloToTcp/StablehloToTcp.h"],
     strip_include_prefix = "include",
     deps = [
         ":TcpConversionPassesIncGen",
@@ -259,16 +184,12 @@ cc_library(
 
 cc_library(
     name = "TcpToLinalg",
-    srcs = [
-        "lib/Conversion/PassDetail.h",
-        "lib/Conversion/TcpToLinalg/Elementwise.cpp",
-        "lib/Conversion/TcpToLinalg/Misc.cpp",
-        "lib/Conversion/TcpToLinalg/PopulatePatterns.h",
-        "lib/Conversion/TcpToLinalg/TcpToLinalg.cpp",
-    ],
-    hdrs = [
-        "include/mlir-tcp/Conversion/TcpToLinalg/TcpToLinalg.h",
-    ],
+    srcs = glob([
+        "lib/Conversion/TcpToLinalg/*.h",
+        "lib/Conversion/TcpToLinalg/*.cpp",
+        "lib/Conversion/*.h",
+    ]),
+    hdrs = ["include/mlir-tcp/Conversion/TcpToLinalg/TcpToLinalg.h"],
     strip_include_prefix = "include",
     deps = [
         ":TcpConversionPassesIncGen",
@@ -289,9 +210,7 @@ cc_library(
         "lib/Conversion/PassDetail.h",
         "lib/Conversion/TcpToArith/TcpToArith.cpp",
     ],
-    hdrs = [
-        "include/mlir-tcp/Conversion/TcpToArith/TcpToArith.h",
-    ],
+    hdrs = ["include/mlir-tcp/Conversion/TcpToArith/TcpToArith.h"],
     strip_include_prefix = "include",
     deps = [
         ":TcpConversionPassesIncGen",
@@ -307,12 +226,8 @@ cc_library(
 
 cc_library(
     name = "TcpInitAll",
-    srcs = [
-        "lib/InitAll.cpp",
-    ],
-    hdrs = [
-        "include/mlir-tcp/InitAll.h",
-    ],
+    srcs = ["lib/InitAll.cpp"],
+    hdrs = ["include/mlir-tcp/InitAll.h"],
     strip_include_prefix = "include",
     deps = [
         ":TcpConversionPasses",
@@ -327,12 +242,8 @@ cc_library(
 
 cc_library(
     name = "Pipeline",
-    srcs = [
-        "lib/Pipeline/Pipeline.cpp",
-    ],
-    hdrs = [
-        "include/mlir-tcp/Pipeline/Pipeline.h",
-    ],
+    srcs = ["lib/Pipeline/Pipeline.cpp"],
+    hdrs = ["include/mlir-tcp/Pipeline/Pipeline.h"],
     strip_include_prefix = "include",
     deps = [
         ":TcpConversionPasses",
@@ -345,9 +256,7 @@ cc_library(
 
 cc_binary(
     name = "tcp-opt",
-    srcs = [
-        "tools/tcp-opt/tcp-opt.cpp",
-    ],
+    srcs = ["tools/tcp-opt/tcp-opt.cpp"],
     deps = [
         ":Pipeline",
         ":TcpDialect",

--- a/include/mlir-tcp/Dialect/IR/TcpBase.td
+++ b/include/mlir-tcp/Dialect/IR/TcpBase.td
@@ -42,7 +42,7 @@ def Tcp_Dialect : Dialect {
 // Param tuple is: [bitwidth, zeropt, smantissa, sexp, low_end, high_end].
 // Where low and high ends are 0,255 when unsigned, -128,127 when signed, for
 // the 8-bit case.
-class TCP_QuantizedType<string n, list<int> params, bit signed>
+class Tcp_QuantizedType<string n, list<int> params, bit signed>
   : Type<And<[CPred<"$_self.isa<mlir::quant::QuantizedType>()">,
               CPred<"$_self.cast<mlir::quant::QuantizedType>()" #
                     ".getStorageTypeIntegralWidth() == " # !head(params)>]>,
@@ -63,12 +63,12 @@ class TCP_QuantizedType<string n, list<int> params, bit signed>
 // q8ss  : symmetric          signed
 // q16ss : symmetric          signed
 //===----------------------------------------------------------------------===//
-def TCP_QuantizedInt	: AnyTypeOf<[ TCP_QuantizedType<"q8ua", [8], 0>,
-                                     TCP_QuantizedType<"q8sa", [8], 1>,
-                                     TCP_QuantizedType<"q8ss", [8, 0], 1>,
-                                     TCP_QuantizedType<"q16ss", [16, 0], 1>]>;
+def Tcp_QuantizedInt	: AnyTypeOf<[Tcp_QuantizedType<"q8ua", [8], 0>,
+                                     Tcp_QuantizedType<"q8sa", [8], 1>,
+                                     Tcp_QuantizedType<"q8ss", [8, 0], 1>,
+                                     Tcp_QuantizedType<"q16ss", [16, 0], 1>]>;
 
-def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, TCP_QuantizedInt]>;
+def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, Tcp_QuantizedInt]>;
 def Tcp_Tensor : RankedTensorOf<[Tcp_Scalar]>;
 def Tcp_TensorOrScalar : AnyTypeOf<[Tcp_Tensor, Tcp_Scalar]>;
 

--- a/lib/Conversion/TorchToTcp/TorchToTcp.cpp
+++ b/lib/Conversion/TorchToTcp/TorchToTcp.cpp
@@ -75,8 +75,7 @@ public:
 
 } // namespace
 
-std::unique_ptr<OperationPass<func::FuncOp>>
-mlir::tcp::createConvertTorchToTcpPass() {
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTcpPass() {
   return std::make_unique<ConvertTorchToTcp>();
 }
 


### PR DESCRIPTION
This is idiomatic to usage in upstream MLIR. Includes other minor cleanup.