### PR TITLE
[Dialect] Traits and type parser/printer fixes to unblock downstream integrations

### DIFF
--- a/include/mlir-tcp/Conversion/Passes.h
+++ b/include/mlir-tcp/Conversion/Passes.h
@@ -12,7 +12,7 @@
 namespace mlir {
 namespace tcp {
 
-void registerConversionPasses();
+void registerTcpConversionPasses();
 
 } // namespace tcp
 } // namespace mlir

--- a/include/mlir-tcp/Dialect/IR/TcpBase.td
+++ b/include/mlir-tcp/Dialect/IR/TcpBase.td
@@ -35,6 +35,8 @@ def Tcp_Dialect : Dialect {
   }]; 
 
   let dependentDialects = [];
+
+  let useDefaultTypePrinterParser = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -239,7 +239,6 @@ def Tcp_YieldOp : Tcp_Op<"yield", [Terminator, Pure]> {
 
 def Tcp_GroupOp : Tcp_Op<"group", [
           AffineScope,
-          ParentOneOf<["func::FuncOp", "tcp::GroupOp", "tcp::IsolatedGroupOp"]>,
           SingleBlockImplicitTerminator<"tcp::YieldOp">]> {
   let summary = "Groups ops into a region that is not isolated from above";
 
@@ -275,7 +274,6 @@ def Tcp_GroupOp : Tcp_Op<"group", [
 def Tcp_IsolatedGroupOp : Tcp_Op<"isolated_group", [
           AffineScope,
           IsolatedFromAbove,
-          ParentOneOf<["func::FuncOp", "tcp::GroupOp", "tcp::IsolatedGroupOp"]>,
           SingleBlockImplicitTerminator<"tcp::YieldOp">]> {
   let summary = "Groups ops into a region that is isolated from above";
 

--- a/include/mlir-tcp/Dialect/IR/TcpTypes.td
+++ b/include/mlir-tcp/Dialect/IR/TcpTypes.td
@@ -16,11 +16,19 @@ include "mlir/IR/DialectBase.td"
 include "mlir-tcp/Dialect/IR/TcpBase.td"
 
 //===----------------------------------------------------------------------===//
-// Tcp Type Definitions.
+// Tcp Type Definitions
+//===----------------------------------------------------------------------===//
+
+def Tcp_IndexArrayType : Tcp_Type<"IndexArray", "index_array"> {
+    let summary = "IndexArray TCP type, to holds a list of index builtin type to represent shape";
+}
+
+//===----------------------------------------------------------------------===//
+// Tcp Quantized Types
 //===----------------------------------------------------------------------===//
 
 // The base class of a quantized type.
-// Param tuple is: [bitwidth, zeropt, smantissa, sexp, low_end, high_end].
+// Param tuple is: [bitwidth, zero_pt, s_mantissa, s_exp, low_end, high_end].
 // Where low and high ends are 0,255 when unsigned, -128,127 when signed, for
 // the 8-bit case.
 class Tcp_QuantizedType<string n, list<int> params, bit signed>
@@ -34,9 +42,6 @@ class Tcp_QuantizedType<string n, list<int> params, bit signed>
 }
 
 //===----------------------------------------------------------------------===//
-// Quantized Integer Types.
-//===----------------------------------------------------------------------===//
-//===----------------------------------------------------------------------===//
 // Name    Symmetry           Sign
 //===----------------------------------------------------------------------===//
 // q8ua  : asymmetric         unsigned
@@ -48,6 +53,10 @@ def Tcp_QuantizedInt	: AnyTypeOf<[Tcp_QuantizedType<"q8ua", [8], 0>,
                                      Tcp_QuantizedType<"q8sa", [8], 1>,
                                      Tcp_QuantizedType<"q8ss", [8, 0], 1>,
                                      Tcp_QuantizedType<"q16ss", [16, 0], 1>]>;
+
+//===----------------------------------------------------------------------===//
+// Tcp Container Types
+//===----------------------------------------------------------------------===//
 
 def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, Tcp_QuantizedInt]>;
 def Tcp_Tensor : RankedTensorOf<[Tcp_Scalar]>;

--- a/include/mlir-tcp/Dialect/IR/TcpTypes.td
+++ b/include/mlir-tcp/Dialect/IR/TcpTypes.td
@@ -15,18 +15,10 @@ include "mlir/IR/DialectBase.td"
 
 include "mlir-tcp/Dialect/IR/TcpBase.td"
 
-//===----------------------------------------------------------------------===//
-// Tcp Type Definitions
-//===----------------------------------------------------------------------===//
-
-def Tcp_IndexArrayType : Tcp_Type<"IndexArray", "index_array"> {
-    let summary = "IndexArray TCP type, to holds a list of index builtin type to represent shape";
-}
 
 //===----------------------------------------------------------------------===//
 // Tcp Quantized Types
 //===----------------------------------------------------------------------===//
-
 // The base class of a quantized type.
 // Param tuple is: [bitwidth, zero_pt, s_mantissa, s_exp, low_end, high_end].
 // Where low and high ends are 0,255 when unsigned, -128,127 when signed, for
@@ -40,7 +32,6 @@ class Tcp_QuantizedType<string n, list<int> params, bit signed>
   string asTraitArgsStr = !interleave(params, ", ") #
                           !if(signed, ", true", ", false");
 }
-
 //===----------------------------------------------------------------------===//
 // Name    Symmetry           Sign
 //===----------------------------------------------------------------------===//
@@ -54,8 +45,9 @@ def Tcp_QuantizedInt	: AnyTypeOf<[Tcp_QuantizedType<"q8ua", [8], 0>,
                                      Tcp_QuantizedType<"q8ss", [8, 0], 1>,
                                      Tcp_QuantizedType<"q16ss", [16, 0], 1>]>;
 
+
 //===----------------------------------------------------------------------===//
-// Tcp Container Types
+// Tcp Basic Types
 //===----------------------------------------------------------------------===//
 
 def Tcp_Scalar : AnyTypeOf<[AnyFloat, AnySignlessInteger, Tcp_QuantizedInt]>;
@@ -64,5 +56,14 @@ def Tcp_TensorOrScalar : AnyTypeOf<[Tcp_Tensor, Tcp_Scalar]>;
 
 def Tcp_FloatTensor : RankedTensorOf<[AnyFloat]>;
 def Tcp_FloatOrIntTensor : RankedTensorOf<[AnyFloat, AnySignlessInteger]>;
+
+
+//===----------------------------------------------------------------------===//
+// Tcp Custom Types
+//===----------------------------------------------------------------------===//
+
+def Tcp_IndexArrayType : Tcp_Type<"IndexArray", "index_array"> {
+    let summary = "IndexArray TCP type, to holds a list of index builtin type to represent shape";
+}
 
 #endif // TCP_TYPES

--- a/include/mlir-tcp/Dialect/Transforms/Passes.h
+++ b/include/mlir-tcp/Dialect/Transforms/Passes.h
@@ -15,6 +15,6 @@
 namespace mlir::tcp {
 
 /// Registers all Tcp related passes.
-void registerTcpPasses();
+void registerTcpDialectPasses();
 
 } // namespace mlir::tcp

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -23,4 +23,4 @@ namespace {
 #include "mlir-tcp/Conversion/Passes.h.inc"
 } // end namespace
 
-void mlir::tcp::registerConversionPasses() { ::registerPasses(); }
+void mlir::tcp::registerTcpConversionPasses() { ::registerPasses(); }

--- a/lib/Dialect/Transforms/Passes.cpp
+++ b/lib/Dialect/Transforms/Passes.cpp
@@ -19,4 +19,4 @@ namespace {
 #include "mlir-tcp/Dialect/Transforms/Passes.h.inc"
 } // end namespace
 
-void mlir::tcp::registerTcpPasses() { ::registerPasses(); }
+void mlir::tcp::registerTcpDialectPasses() { ::registerPasses(); }

--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -25,6 +25,6 @@ void mlir::tcp::registerAllDialects(mlir::DialectRegistry &registry) {
 }
 
 void mlir::tcp::registerAllPasses() {
-  mlir::tcp::registerConversionPasses();
-  mlir::tcp::registerTcpPasses();
+  mlir::tcp::registerTcpConversionPasses();
+  mlir::tcp::registerTcpDialectPasses();
 }


### PR DESCRIPTION
- [x] Remove ParentOneOf trait from tcp group ops
  - No longer a constraint; fixes `error: 'tcp.isolated_group' op expects parent op to be one of 'func.func, tcp.group, tcp.isolated_group'`
- [x] Use default type parser/printer for TcpDialect
  - Used downstream; fixes `error: dialect 'tcp' provides no type parsing hook`
- [x] Add `Tcp_IndexArrayType` definition
  - Fixes `ld.lld: error: undefined symbol: mlir::tcp::TcpDialect::printType(mlir::Type, mlir::DialectAsmPrinter&) const` `referenced by TcpDialect.cpp`
- [x] Minor: rename pass registration