### PR TITLE
Allow partial `TorchToTcp` conversions using a whitelist

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -203,6 +203,7 @@ cc_library(
         "@torch-mlir//:TorchMLIRConversionUtils",
         "@torch-mlir//:TorchMLIRTorchBackendTypeConversion",
         "@torch-mlir//:TorchMLIRTorchConversionDialect",
+        "@torch-mlir//:TorchMLIRTorchPasses",
     ],
 )
 

--- a/include/mlir-tcp/Conversion/Passes.td
+++ b/include/mlir-tcp/Conversion/Passes.td
@@ -21,7 +21,12 @@ def ConvertTorchToTcp : Pass<"convert-torch-to-tcp", "func::FuncOp"> {
   let description = [{
     Convert Torch ops to Tcp ops.
   }];
-  let constructor = "mlir::tcp::createConvertTorchToTcpPass()";
+  let constructor = "mlir::tcp::createConvertTorchToTcpPass(/*convertTorchOps=*/{})";
+  let options = [
+    ListOption<"convertTorchOps", "convert-torch-ops", "std::string",
+               "List of Torch operation names that should be converted to Tcp",
+               "llvm::cl::ZeroOrMore">
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h
+++ b/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h
@@ -19,7 +19,8 @@ namespace mlir {
 
 namespace tcp {
 
-std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTcpPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTorchToTcpPass(llvm::ArrayRef<std::string> convertTorchOps);
 
 } // namespace tcp
 } // namespace mlir

--- a/lib/Conversion/TorchToTcp/DataMovement.cpp
+++ b/lib/Conversion/TorchToTcp/DataMovement.cpp
@@ -18,6 +18,8 @@
 #include "torch-mlir/Dialect/Torch/IR/TorchOps.h"
 #include "torch-mlir/Dialect/Torch/Utils/Utils.h"
 
+#include "llvm/ADT/StringSet.h"
+
 using namespace mlir;
 using namespace mlir::tcp;
 using namespace mlir::torch;
@@ -60,8 +62,7 @@ public:
 
 void torch_to_tcp::populateDataMovementPatternsAndLegality(
     TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
-  target.addIllegalOp<AtenCatOp>();
-  patterns.add<ConvertAtenCatOp>(typeConverter, context);
+    ConversionTarget &target, const llvm::StringSet<> &convertTorchOpsSet) {
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<ConvertAtenCatOp, AtenCatOp>(
+      typeConverter, patterns, target, convertTorchOpsSet);
 }

--- a/lib/Conversion/TorchToTcp/Elementwise.cpp
+++ b/lib/Conversion/TorchToTcp/Elementwise.cpp
@@ -652,15 +652,14 @@ void torch_to_tcp::populateElementwisePatternsAndLegality(
     TypeConverter &typeConverter, RewritePatternSet &patterns,
     ConversionTarget &target, const llvm::StringSet<> &convertTorchOpsSet) {
 
-#define INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenOpPattern, AtenOp)       \
-  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<ConvertAtenOpPattern,       \
-                                                   AtenOp>(                    \
+#define INSERT_ATEN_ELEMENTWISE_OP_PATTERN(AtenOp)                             \
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<Convert##AtenOp, AtenOp>(   \
       typeConverter, patterns, target, convertTorchOpsSet)
-  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenToDtypeOp, AtenToDtypeOp);
-  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenClampOp, AtenClampOp);
-  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenReluOp, AtenReluOp);
-  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenBatchNormOp, AtenBatchNormOp);
-  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenAtan2Op, AtenAtan2Op);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(AtenToDtypeOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(AtenClampOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(AtenReluOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(AtenBatchNormOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(AtenAtan2Op);
 #undef INSERT_ATEN_ELEMENTWISE_OP_PATTERN
 
 #define INSERT_ATEN_ELEMENTWISE_ADD_SUB_PATTERN(AtenOp, TcpOp)                 \

--- a/lib/Conversion/TorchToTcp/Elementwise.cpp
+++ b/lib/Conversion/TorchToTcp/Elementwise.cpp
@@ -650,78 +650,59 @@ public:
 
 void torch_to_tcp::populateElementwisePatternsAndLegality(
     TypeConverter &typeConverter, RewritePatternSet &patterns,
-    ConversionTarget &target) {
-  MLIRContext *context = patterns.getContext();
+    ConversionTarget &target, const llvm::StringSet<> &convertTorchOpsSet) {
 
-  target.addIllegalOp<AtenToDtypeOp>();
-  patterns.add<ConvertAtenToDtypeOp>(typeConverter, context);
+#define INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenOpPattern, AtenOp)       \
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<ConvertAtenOpPattern,       \
+                                                   AtenOp>(                    \
+      typeConverter, patterns, target, convertTorchOpsSet)
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenToDtypeOp, AtenToDtypeOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenClampOp, AtenClampOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenReluOp, AtenReluOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenBatchNormOp, AtenBatchNormOp);
+  INSERT_ATEN_ELEMENTWISE_OP_PATTERN(ConvertAtenAtan2Op, AtenAtan2Op);
+#undef INSERT_ATEN_ELEMENTWISE_OP_PATTERN
 
-  target.addIllegalOp<AtenClampOp>();
-  patterns.add<ConvertAtenClampOp>(typeConverter, context);
-  target.addIllegalOp<AtenReluOp>();
-  patterns.add<ConvertAtenReluOp>(typeConverter, context);
+#define INSERT_ATEN_ELEMENTWISE_ADD_SUB_PATTERN(AtenOp, TcpOp)                 \
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<                            \
+      ConvertAtenAddSubOp<AtenOp, TcpOp>, AtenOp>(typeConverter, patterns,     \
+                                                  target, convertTorchOpsSet)
+  INSERT_ATEN_ELEMENTWISE_ADD_SUB_PATTERN(AtenAddTensorOp, tcp::AddOp);
+  INSERT_ATEN_ELEMENTWISE_ADD_SUB_PATTERN(AtenSubTensorOp, tcp::SubOp);
+  INSERT_ATEN_ELEMENTWISE_ADD_SUB_PATTERN(AtenAddScalarOp, tcp::AddOp);
+  INSERT_ATEN_ELEMENTWISE_ADD_SUB_PATTERN(AtenSubScalarOp, tcp::SubOp);
+#undef INSERT_ATEN_ELEMENTWISE_ADD_SUB_PATTERN
 
-  target.addIllegalOp<AtenAddTensorOp>();
-  target.addIllegalOp<AtenSubTensorOp>();
-  target.addIllegalOp<AtenAddScalarOp>();
-  target.addIllegalOp<AtenSubScalarOp>();
-  patterns.add<ConvertAtenAddSubOp<AtenAddTensorOp, tcp::AddOp>>(typeConverter,
-                                                                 context);
-  patterns.add<ConvertAtenAddSubOp<AtenSubTensorOp, tcp::SubOp>>(typeConverter,
-                                                                 context);
-  patterns.add<ConvertAtenAddSubOp<AtenAddScalarOp, tcp::AddOp>>(typeConverter,
-                                                                 context);
-  patterns.add<ConvertAtenAddSubOp<AtenSubScalarOp, tcp::SubOp>>(typeConverter,
-                                                                 context);
+#define INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN(ConvertAtenOpPattern, AtenOp)  \
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<                            \
+      ConvertAtenOpPattern<AtenOp>, AtenOp>(typeConverter, patterns, target,   \
+                                            convertTorchOpsSet)
+  INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN(ConvertAtenMulOp, AtenMulTensorOp);
+  INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN(ConvertAtenMulOp, AtenMulScalarOp);
+  INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN(ConvertAtenDivOp, AtenDivTensorOp);
+  INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN(ConvertAtenDivOp, AtenDivScalarOp);
+#undef INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN
 
-  target.addIllegalOp<AtenMulTensorOp>();
-  target.addIllegalOp<AtenMulScalarOp>();
-  patterns.add<ConvertAtenMulOp<AtenMulTensorOp>>(typeConverter, context);
-  patterns.add<ConvertAtenMulOp<AtenMulScalarOp>>(typeConverter, context);
+#define INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenOp, TcpOp)                       \
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<                            \
+      ConvertAtenUnaryFpOnlyOp<AtenOp, TcpOp>, AtenOp>(                        \
+      typeConverter, patterns, target, convertTorchOpsSet)
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenCeilOp, tcp::CeilOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenFloorOp, tcp::FloorOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenSigmoidOp, tcp::SigmoidOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenTanhOp, tcp::TanhOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenSinOp, tcp::SinOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenCosOp, tcp::CosOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenLogOp, tcp::LogOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenNegOp, tcp::NegOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenAtanOp, tcp::AtanOp);
+#undef INSERT_ATEN_UNARY_FP_ONLY_PATTERN
 
-  target.addIllegalOp<AtenDivTensorOp>();
-  target.addIllegalOp<AtenDivScalarOp>();
-  patterns.add<ConvertAtenDivOp<AtenDivTensorOp>>(typeConverter, context);
-  patterns.add<ConvertAtenDivOp<AtenDivScalarOp>>(typeConverter, context);
-
-  target.addIllegalOp<AtenCeilOp>();
-  target.addIllegalOp<AtenFloorOp>();
-  target.addIllegalOp<AtenSigmoidOp>();
-  target.addIllegalOp<AtenTanhOp>();
-  target.addIllegalOp<AtenSinOp>();
-  target.addIllegalOp<AtenCosOp>();
-  target.addIllegalOp<AtenLogOp>();
-  target.addIllegalOp<AtenNegOp>();
-  target.addIllegalOp<AtenAtanOp>();
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenFloorOp, tcp::FloorOp>>(
-      typeConverter, context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenCeilOp, tcp::CeilOp>>(typeConverter,
-                                                                  context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenSigmoidOp, tcp::SigmoidOp>>(
-      typeConverter, context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenTanhOp, tcp::TanhOp>>(typeConverter,
-                                                                  context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenSinOp, tcp::SinOp>>(typeConverter,
-                                                                context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenCosOp, tcp::CosOp>>(typeConverter,
-                                                                context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenLogOp, tcp::LogOp>>(typeConverter,
-                                                                context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenNegOp, tcp::NegOp>>(typeConverter,
-                                                                context);
-  patterns.add<ConvertAtenUnaryFpOnlyOp<AtenAtanOp, tcp::AtanOp>>(typeConverter,
-                                                                  context);
-
-  target.addIllegalOp<AtenAbsOp>();
-  target.addIllegalOp<AtenSqrtOp>();
-  patterns.add<ConvertAtenUnaryIntOrFpOp<AtenAbsOp, tcp::AbsOp>>(typeConverter,
-                                                                 context);
-  patterns.add<ConvertAtenUnaryIntOrFpOp<AtenSqrtOp, tcp::SqrtOp>>(
-      typeConverter, context);
-
-  target.addIllegalOp<AtenBatchNormOp>();
-  patterns.add<ConvertAtenBatchNormOp>(typeConverter, context);
-
-  target.addIllegalOp<AtenAtan2Op>();
-  patterns.add<ConvertAtenAtan2Op>(typeConverter, context);
+#define INSERT_ATEN_UNARY_INT_OR_FP_PATTERN(AtenOp, TcpOp)                     \
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<                            \
+      ConvertAtenUnaryIntOrFpOp<AtenOp, TcpOp>, AtenOp>(                       \
+      typeConverter, patterns, target, convertTorchOpsSet)
+  INSERT_ATEN_UNARY_INT_OR_FP_PATTERN(AtenAbsOp, tcp::AbsOp);
+  INSERT_ATEN_UNARY_INT_OR_FP_PATTERN(AtenSqrtOp, tcp::SqrtOp);
+#undef INSERT_ATEN_UNARY_INT_OR_FP_PATTERN
 }

--- a/lib/Conversion/TorchToTcp/Misc.cpp
+++ b/lib/Conversion/TorchToTcp/Misc.cpp
@@ -224,13 +224,11 @@ void torch_to_tcp::populateMiscPatternsAndLegality(
     TypeConverter &typeConverter, RewritePatternSet &patterns,
     ConversionTarget &target, const llvm::StringSet<> &convertTorchOpsSet) {
 
-#define INSERT_ATEN_MISC_OP_PATTERN(ConvertAtenOpPattern, AtenOp)              \
-  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<ConvertAtenOpPattern,       \
-                                                   AtenOp>(                    \
+#define INSERT_ATEN_MISC_OP_PATTERN(AtenOp)                                    \
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<Convert##AtenOp, AtenOp>(   \
       typeConverter, patterns, target, convertTorchOpsSet)
-  INSERT_ATEN_MISC_OP_PATTERN(ConvertAtenBroadcastToOp, AtenBroadcastToOp);
-  INSERT_ATEN_MISC_OP_PATTERN(ConvertValueTensorLiteralOp,
-                              ValueTensorLiteralOp);
+  INSERT_ATEN_MISC_OP_PATTERN(AtenBroadcastToOp);
+  INSERT_ATEN_MISC_OP_PATTERN(ValueTensorLiteralOp);
 #undef INSERT_ATEN_MISC_OP_PATTERN
 
 #define INSERT_ATEN_ZEROS_ONES_PATTERN(ConvertAtenOpPattern, AtenOp, Val)      \

--- a/lib/Conversion/TorchToTcp/PopulatePatterns.h
+++ b/lib/Conversion/TorchToTcp/PopulatePatterns.h
@@ -9,19 +9,22 @@
 
 #include "mlir/Transforms/DialectConversion.h"
 
+#include "llvm/ADT/StringSet.h"
+
 namespace mlir {
 namespace torch_to_tcp {
 
-void populateElementwisePatternsAndLegality(TypeConverter &typeConverter,
-                                            RewritePatternSet &patterns,
-                                            ConversionTarget &target);
-void populateMiscPatternsAndLegality(TypeConverter &typeConverter,
-                                     RewritePatternSet &patterns,
-                                     ConversionTarget &target);
+void populateElementwisePatternsAndLegality(
+    TypeConverter &typeConverter, RewritePatternSet &patterns,
+    ConversionTarget &target, const llvm::StringSet<> &convertTorchOpsSet);
 
-void populateDataMovementPatternsAndLegality(TypeConverter &typeConverter,
-                                             RewritePatternSet &patterns,
-                                             ConversionTarget &target);
+void populateMiscPatternsAndLegality(
+    TypeConverter &typeConverter, RewritePatternSet &patterns,
+    ConversionTarget &target, const llvm::StringSet<> &convertTorchOpsSet);
+
+void populateDataMovementPatternsAndLegality(
+    TypeConverter &typeConverter, RewritePatternSet &patterns,
+    ConversionTarget &target, const llvm::StringSet<> &convertTorchOpsSet);
 
 } // namespace torch_to_tcp
 } // namespace mlir

--- a/lib/Conversion/TorchToTcp/TorchToTcp.cpp
+++ b/lib/Conversion/TorchToTcp/TorchToTcp.cpp
@@ -62,10 +62,9 @@ public:
     MLIRContext *context = &getContext();
     RewritePatternSet patterns(context);
 
-    // The strings in the `convertTorchOps` ArrayRef don't exist during the call
-    // to the constructor `ConvertTorchToTcp`, so the creation of the
-    // `convertTorchOpsSet` must be delayed to when `runOnOperation` gets
-    // called.
+    // Usually the default constructor is called which means `convertTorchOps`
+    // is usually unset. Doing this here allows the initialization of
+    // `convertTorchOpsSet` to be be delayed to when `runOnOperation` is called.
     convertTorchOpsSet.clear();
     convertTorchOpsSet.insert(convertTorchOps.begin(), convertTorchOps.end());
 

--- a/lib/Pipeline/Pipeline.cpp
+++ b/lib/Pipeline/Pipeline.cpp
@@ -35,10 +35,7 @@
 using namespace mlir;
 
 static void createTorchBackendToTcpBackendPipeline(OpPassManager &pm) {
-  ArrayRef<std::string> emptyArrayRef;
-
-  pm.addNestedPass<func::FuncOp>(
-      tcp::createConvertTorchToTcpPass(emptyArrayRef));
+  pm.addNestedPass<func::FuncOp>(tcp::createConvertTorchToTcpPass({}));
 
   // Clean up any non-canonical code introduced above.
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/lib/Pipeline/Pipeline.cpp
+++ b/lib/Pipeline/Pipeline.cpp
@@ -35,7 +35,10 @@
 using namespace mlir;
 
 static void createTorchBackendToTcpBackendPipeline(OpPassManager &pm) {
-  pm.addNestedPass<func::FuncOp>(tcp::createConvertTorchToTcpPass());
+  ArrayRef<std::string> emptyArrayRef;
+
+  pm.addNestedPass<func::FuncOp>(
+      tcp::createConvertTorchToTcpPass(emptyArrayRef));
 
   // Clean up any non-canonical code introduced above.
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/test/Conversion/TorchToTcp/partial_conversion.mlir
+++ b/test/Conversion/TorchToTcp/partial_conversion.mlir
@@ -1,0 +1,40 @@
+// RUN: tcp-opt %s -convert-torch-to-tcp="convert-torch-ops=aten.atan"    -verify-diagnostics | FileCheck %s -check-prefix=CHECK1
+// RUN: tcp-opt %s -convert-torch-to-tcp="convert-torch-ops=aten.log"     -verify-diagnostics | FileCheck %s -check-prefix=CHECK2
+// RUN: tcp-opt %s -convert-torch-to-tcp="convert-torch-ops=aten.sigmoid" -verify-diagnostics | FileCheck %s -check-prefix=CHECK3
+// RUN: tcp-opt %s -convert-torch-to-tcp                                  -verify-diagnostics | FileCheck %s -check-prefix=CHECK4
+
+// CHECK1-LABEL:  func.func @torch.aten.atan.log(
+// CHECK1-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK1:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
+// CHECK1:         %[[T1:.*]] = tcp.atan %[[T0]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK1:         %[[T2:.*]] = torch_c.from_builtin_tensor %[[T1]] : tensor<?x?xf32> -> !torch.vtensor<[?,?],f32>
+// CHECK1:         %[[T3:.*]] = torch.aten.log %[[T2]] : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+// CHECK1:         return %[[T3]] : !torch.vtensor<[?,?],f32>
+
+// CHECK2-LABEL:  func.func @torch.aten.atan.log(
+// CHECK2-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK2:         %[[T0:.*]] = torch.aten.atan %[[ARG0]] : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+// CHECK2:         %[[T1:.*]] = torch_c.to_builtin_tensor %[[T0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
+// CHECK2:         %[[T2:.*]] = tcp.log %[[T1]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK2:         %[[T3:.*]] = torch_c.from_builtin_tensor %[[T2]] : tensor<?x?xf32> -> !torch.vtensor<[?,?],f32>
+// CHECK2:         return %[[T3]] : !torch.vtensor<[?,?],f32>
+
+// CHECK3-LABEL:  func.func @torch.aten.atan.log(
+// CHECK3-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK3:         %[[T0:.*]] = torch.aten.atan %[[ARG0]] : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+// CHECK3:         %[[T1:.*]] = torch.aten.log %[[T0]] : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+// CHECK3:         return %[[T1]] : !torch.vtensor<[?,?],f32>
+
+// CHECK4-LABEL:  func.func @torch.aten.atan.log(
+// CHECK4-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK4:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
+// CHECK4:         %[[T1:.*]] = tcp.atan %[[T0]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK4:         %[[T2:.*]] = tcp.log %[[T1]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK4:         %[[T3:.*]] = torch_c.from_builtin_tensor %[[T2]] : tensor<?x?xf32> -> !torch.vtensor<[?,?],f32>
+// CHECK4:         return %[[T3]] : !torch.vtensor<[?,?],f32>
+
+func.func @torch.aten.atan.log(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.atan %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  %1 = torch.aten.log %0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %1 : !torch.vtensor<[?,?],f32>
+}


### PR DESCRIPTION
Add pass option to TorchToTcp accepting a set of op name strings as whitelist (for selective conversion). This allows flexibility with phase ordering of conversion passes in downstream pipelines.