### PR TITLE
Add default call to `createConvertTorchToTcpPass`

### DIFF
--- a/include/mlir-tcp/Conversion/Passes.td
+++ b/include/mlir-tcp/Conversion/Passes.td
@@ -21,11 +21,11 @@ def ConvertTorchToTcp : Pass<"convert-torch-to-tcp", "func::FuncOp"> {
   let description = [{
     Convert Torch ops to Tcp ops.
   }];
-  let constructor = "mlir::tcp::createConvertTorchToTcpPass(/*convertTorchOps=*/{})";
+  let constructor = "mlir::tcp::createConvertTorchToTcpPass()";
   let options = [
     ListOption<"convertTorchOps", "convert-torch-ops", "std::string",
                "List of Torch operation names that should be converted to Tcp",
-               "llvm::cl::ZeroOrMore">
+               "llvm::cl::ZeroOrMore">,
   ];
 }
 

--- a/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h
+++ b/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h
@@ -19,6 +19,7 @@ namespace mlir {
 
 namespace tcp {
 
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTcpPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertTorchToTcpPass(llvm::ArrayRef<std::string> convertTorchOps);
 

--- a/lib/Conversion/TorchToTcp/TorchToTcp.cpp
+++ b/lib/Conversion/TorchToTcp/TorchToTcp.cpp
@@ -97,6 +97,11 @@ public:
 
 } // namespace
 
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTcpPass() {
+  llvm::ArrayRef<std::string> emptyArrayRef;
+  return std::make_unique<ConvertTorchToTcp>(/*convertTorchOps=*/emptyArrayRef);
+}
+
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertTorchToTcpPass(llvm::ArrayRef<std::string> convertTorchOps) {
   return std::make_unique<ConvertTorchToTcp>(convertTorchOps);

--- a/lib/Pipeline/Pipeline.cpp
+++ b/lib/Pipeline/Pipeline.cpp
@@ -35,7 +35,7 @@
 using namespace mlir;
 
 static void createTorchBackendToTcpBackendPipeline(OpPassManager &pm) {
-  pm.addNestedPass<func::FuncOp>(tcp::createConvertTorchToTcpPass({}));
+  pm.addNestedPass<func::FuncOp>(tcp::createConvertTorchToTcpPass());
 
   // Clean up any non-canonical code introduced above.
   pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());


### PR DESCRIPTION
Slightly improves user-interface by allowing pipelines to add the default ConvertTorchToTcpPass without an empty ArrayRef:
```
-  pm.addNestedPass<func::FuncOp>(tcp::createConvertTorchToTcpPass({}));
+  pm.addNestedPass<func::FuncOp>(tcp::createConvertTorchToTcpPass());
```