### PR TITLE
Separate conversion pass for `torch -> tcp.custom_op` to support both kernel and codegen approaches

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -192,10 +192,14 @@ cc_library(
         "lib/Conversion/TorchToTcp/PopulatePatterns.h",
         "lib/Conversion/TorchToTcp/TcpCustomOp.cpp",
         "lib/Conversion/TorchToTcp/TorchToTcp.cpp",
+        "lib/Conversion/TorchToTcp/TorchToTcpCustomOp.cpp",
         "lib/Conversion/TorchToTcp/Utils.cpp",
         "lib/Conversion/TorchToTcp/Utils.h",
     ],
-    hdrs = ["include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h"],
+    hdrs = [
+        "include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h",
+        "include/mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h",
+    ],
     strip_include_prefix = "include",
     deps = [
         ":TcpConversionPassesIncGen",

--- a/include/mlir-tcp/Conversion/Passes.td
+++ b/include/mlir-tcp/Conversion/Passes.td
@@ -30,6 +30,23 @@ def ConvertTorchToTcp : Pass<"convert-torch-to-tcp", "func::FuncOp"> {
 }
 
 //===----------------------------------------------------------------------===//
+// TorchToTcpCustomOp
+//===----------------------------------------------------------------------===//
+
+def ConvertTorchToTcpCustomOp : Pass<"convert-torch-to-tcp-custom-op", "func::FuncOp"> {
+  let summary = "Convert Torch ops to Tcp custom ops";
+  let description = [{
+    Convert Torch ops to Tcp custom ops.
+  }];
+  let constructor = "mlir::tcp::createConvertTorchToTcpCustomOpPass()";
+  let options = [
+    ListOption<"convertTorchOps", "convert-torch-ops", "std::string",
+               "List of Torch operation names that should be converted to Tcp custom op",
+               "llvm::cl::ZeroOrMore">,
+  ];
+}
+
+//===----------------------------------------------------------------------===//
 // StablehloToTcp
 //===----------------------------------------------------------------------===//
 

--- a/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h
+++ b/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h
@@ -20,6 +20,7 @@ namespace mlir {
 namespace tcp {
 
 std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTcpPass();
+
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertTorchToTcpPass(llvm::ArrayRef<std::string> convertTorchOps);
 

--- a/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h
+++ b/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h
@@ -21,6 +21,7 @@ namespace tcp {
 
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertTorchToTcpCustomOpPass();
+
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertTorchToTcpCustomOpPass(
     llvm::ArrayRef<std::string> convertTorchOps);

--- a/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h
+++ b/include/mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h
@@ -1,0 +1,29 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+#define GEN_PASS_DECL_CONVERTTORCHTOTCPCUSTOMOP
+#include "mlir-tcp/Conversion/Passes.h.inc"
+
+namespace tcp {
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTorchToTcpCustomOpPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTorchToTcpCustomOpPass(
+    llvm::ArrayRef<std::string> convertTorchOps);
+
+} // namespace tcp
+} // namespace mlir

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -13,6 +13,7 @@
 #include "mlir-tcp/Conversion/TcpToArith/TcpToArith.h"
 #include "mlir-tcp/Conversion/TcpToLinalg/TcpToLinalg.h"
 #include "mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h"
+#include "mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h"
 
 //===----------------------------------------------------------------------===//
 // Pass registration

--- a/lib/Conversion/TorchToTcp/TorchToTcpCustomOp.cpp
+++ b/lib/Conversion/TorchToTcp/TorchToTcpCustomOp.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h"
+#include "mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h"
 
 #include "mlir-tcp/Dialect/IR/TcpDialect.h"
 #include "mlir-tcp/Dialect/IR/TcpOps.h"
@@ -35,20 +35,21 @@ using namespace mlir::torch::Torch;
 
 namespace mlir {
 
-#define GEN_PASS_DEF_CONVERTTORCHTOTCP
+#define GEN_PASS_DEF_CONVERTTORCHTOTCPCUSTOMOP
 #include "mlir-tcp/Conversion/Passes.h.inc"
 
 namespace tcp {
 
 namespace {
 
-class ConvertTorchToTcp : public ConvertTorchToTcpBase<ConvertTorchToTcp> {
+class ConvertTorchToTcpCustomOp
+    : public ConvertTorchToTcpCustomOpBase<ConvertTorchToTcpCustomOp> {
 private:
   llvm::StringSet<> convertTorchOpsSet;
 
 public:
-  ConvertTorchToTcp() = default;
-  ConvertTorchToTcp(ArrayRef<std::string> convertTorchOps) {
+  ConvertTorchToTcpCustomOp() = default;
+  ConvertTorchToTcpCustomOp(ArrayRef<std::string> convertTorchOps) {
     this->convertTorchOps = convertTorchOps;
   }
 
@@ -76,13 +77,7 @@ public:
     typeConverter.addConversion([](Type type) { return type; });
     TorchConversion::setupBackendTypeConversion(target, typeConverter);
 
-    torch_to_tcp::populateElementwisePatternsAndLegality(
-        typeConverter, patterns, target, convertTorchOpsSet);
-
-    torch_to_tcp::populateMiscPatternsAndLegality(typeConverter, patterns,
-                                                  target, convertTorchOpsSet);
-
-    torch_to_tcp::populateDataMovementPatternsAndLegality(
+    torch_to_tcp::populateTcpCustomOpPatternsAndLegality(
         typeConverter, patterns, target, convertTorchOpsSet);
 
     if (failed(applyPartialConversion(getOperation(), target,
@@ -94,14 +89,17 @@ public:
 
 } // namespace
 
-std::unique_ptr<OperationPass<func::FuncOp>> createConvertTorchToTcpPass() {
+std::unique_ptr<OperationPass<func::FuncOp>>
+createConvertTorchToTcpCustomOpPass() {
   llvm::ArrayRef<std::string> emptyArrayRef;
-  return std::make_unique<ConvertTorchToTcp>(/*convertTorchOps=*/emptyArrayRef);
+  return std::make_unique<ConvertTorchToTcpCustomOp>(
+      /*convertTorchOps=*/emptyArrayRef);
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createConvertTorchToTcpPass(llvm::ArrayRef<std::string> convertTorchOps) {
-  return std::make_unique<ConvertTorchToTcp>(convertTorchOps);
+createConvertTorchToTcpCustomOpPass(
+    llvm::ArrayRef<std::string> convertTorchOps) {
+  return std::make_unique<ConvertTorchToTcpCustomOp>(convertTorchOps);
 }
 
 } // namespace tcp

--- a/test/Conversion/TorchToTcp/tcp_custom_ops.mlir
+++ b/test/Conversion/TorchToTcp/tcp_custom_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: tcp-opt <%s -convert-torch-to-tcp -canonicalize -split-input-file -verify-diagnostics | FileCheck %s
+// RUN: tcp-opt <%s -convert-torch-to-tcp-custom-op -canonicalize -split-input-file -verify-diagnostics | FileCheck %s
 
 // CHECK-LABEL:  func.func @torch.aten.gather_op(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[2,2],si64>


### PR DESCRIPTION
This allows switching between codegen vs kernels approaches, for torch ops that can lower to either tcp ops (codegen) or tcp.custom_op (kernel). Addresses https://github.com/cruise-automation/mlir-tcp/pull/17#discussion_r1382303711 using [Option 2](https://github.com/cruise-automation/mlir-tcp/pull/17#discussion_r1382436616).