### PR TITLE
Support clangd for code completion, navigation and insights

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,6 +35,7 @@ common --enable_platform_specific_config
 # also has lld available.
 build:linux --linkopt=-fuse-ld=lld --host_linkopt=-fuse-ld=lld
 build:linux --config=generic_clang
+
 build:macos --config=generic_clang
 
 # Other compilation modes

--- a/.bazelrc
+++ b/.bazelrc
@@ -28,17 +28,14 @@ build:generic_clang --cxxopt=-Wno-range-loop-analysis --host_cxxopt=-Wno-range-l
 # not the point of the Bazel build to catch usage of deprecated APIs.
 build:generic_clang --copt=-Wno-deprecated --host_copt=-Wno-deprecated
 
-# lld links faster than other linkers. Assume that anybody using clang on linux
-# also has lld available.
-build:clang_linux --linkopt=-fuse-ld=lld --host_linkopt=-fuse-ld=lld
-build:clang_linux --config=generic_clang
-
-build:clang_macos --config=generic_clang
-
 # Automatically detect host platform to pick config
 common --enable_platform_specific_config
-build:linux --config=clang_linux
-build:macos --config=clang_macos
+
+# lld links faster than other linkers. Assume that anybody using clang on linux
+# also has lld available.
+build:linux --linkopt=-fuse-ld=lld --host_linkopt=-fuse-ld=lld
+build:linux --config=generic_clang
+build:macos --config=generic_clang
 
 # Other compilation modes
 build:opt --compilation_mode=opt

--- a/.bazelrc
+++ b/.bazelrc
@@ -46,3 +46,7 @@ build:dbg --compilation_mode=dbg
 
 # GDB builds in dbg mode
 build:gdb --config=dbg
+
+# TODO: migrate all dependencies from WORKSPACE to MODULE.bazel
+# https://bazel.build/external/migration
+common --noenable_bzlmod

--- a/.github/workflows/bazelBuildAndTestTcp.yml
+++ b/.github/workflows/bazelBuildAndTestTcp.yml
@@ -73,7 +73,7 @@ jobs:
                    mlir-tcp:ci \
                    bazel run //tools/buildifier:buildifier
         if [ -n "$(git status --porcelain)" ]; then
-          echo "Please 'bazel run //tools/buildifier:buildifier ' and commit changes."
+          echo "Please 'bazel run //tools/buildifier:buildifier' and commit changes."
           exit 1
         fi
 

--- a/.github/workflows/bazelBuildAndTestTcp.yml
+++ b/.github/workflows/bazelBuildAndTestTcp.yml
@@ -71,9 +71,9 @@ jobs:
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
                    -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
-                   bazel run //:buildifier
+                   bazel run //tools/buildifier:buildifier
         if [ -n "$(git status --porcelain)" ]; then
-          echo "Please 'bazel run //:buildifier' and commit changes."
+          echo "Please 'bazel run //tools/buildifier:buildifier ' and commit changes."
           exit 1
         fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
+# build related
 bazel-bin
 bazel-out
 bazel-mlir-tcp
 bazel-testlogs
 third_party/
+
+# clangd related
+.cache
+compile_commands.json
+external

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+// Configure clangd
+"clangd.detectExtensionConflicts": true,
+"clangd.restartAfterCrash": true,
+"clangd.onConfigChanged": "restart",
+"clangd.arguments": [
+    "--malloc-trim",
+    "--pretty",
+    "--pch-storage=disk",
+    "--background-index",
+    "--header-insertion=never",
+    "--compile-commands-dir=${workspaceFolder}/",
+    "--query-driver=**",
+    "-j=4"
+    ],
+// Disable conflicting settings of the ms-vscode.cpptools extension
+"C_Cpp.intelliSenseEngine": "Disabled",
+"C_Cpp.autocomplete": "Disabled",
+"C_Cpp.errorSquiggles": "Disabled",

--- a/BUILD
+++ b/BUILD
@@ -328,30 +328,3 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 buildifier(
     name = "buildifier",
 )
-
-load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
-
-refresh_compile_commands(
-    name = "refresh_compile_commands",
-    # Targets obtained using the query:
-    #   bazel query 'kind("(cc.*) rule", //...)'
-    targets = {
-        "//:Pipeline": "--config=clang_linux",
-        "//:StablehloToTcp": "--config=clang_linux",
-        "//:TcpConversionPasses": "--config=clang_linux",
-        "//:TcpConversionPassesIncGen": "--config=clang_linux",
-        "//:TcpDialect": "--config=clang_linux",
-        "//:TcpDialectPasses": "--config=clang_linux",
-        "//:TcpDialectPassesIncGen": "--config=clang_linux",
-        "//:TcpInitAll": "--config=clang_linux",
-        "//:TcpOpsIncGen": "--config=clang_linux",
-        "//:TcpToArith": "--config=clang_linux",
-        "//:TcpToLinalg": "--config=clang_linux",
-        "//:TcpTypesIncGen": "--config=clang_linux",
-        "//:TorchToTcp": "--config=clang_linux",
-        "//:tcp-opt": "--config=clang_linux",
-        "//test:AotCompile/test_aot_compiled_basic_tcp_ops": "--config=clang_linux",
-        "//test:aot_compiled_basic_tcp_ops": "--config=clang_linux",
-        "//tools/aot:abi": "--config=clang_linux",
-    },
-)

--- a/BUILD
+++ b/BUILD
@@ -333,8 +333,25 @@ load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile
 
 refresh_compile_commands(
     name = "refresh_compile_commands",
+    # Targets obtained using the query:
+    #   bazel query 'kind("(cc.*) rule", //...)'
     targets = {
+        "//:Pipeline": "--config=clang_linux",
+        "//:StablehloToTcp": "--config=clang_linux",
+        "//:TcpConversionPasses": "--config=clang_linux",
+        "//:TcpConversionPassesIncGen": "--config=clang_linux",
+        "//:TcpDialect": "--config=clang_linux",
+        "//:TcpDialectPasses": "--config=clang_linux",
+        "//:TcpDialectPassesIncGen": "--config=clang_linux",
+        "//:TcpInitAll": "--config=clang_linux",
+        "//:TcpOpsIncGen": "--config=clang_linux",
+        "//:TcpToArith": "--config=clang_linux",
+        "//:TcpToLinalg": "--config=clang_linux",
+        "//:TcpTypesIncGen": "--config=clang_linux",
+        "//:TorchToTcp": "--config=clang_linux",
         "//:tcp-opt": "--config=clang_linux",
-        "//...": "--config=clang_linux",
+        "//test:AotCompile/test_aot_compiled_basic_tcp_ops": "--config=clang_linux",
+        "//test:aot_compiled_basic_tcp_ops": "--config=clang_linux",
+        "//tools/aot:abi": "--config=clang_linux",
     },
 )

--- a/BUILD
+++ b/BUILD
@@ -328,3 +328,13 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 buildifier(
     name = "buildifier",
 )
+
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    targets = {
+        "//:tcp-opt": "--config=clang_linux",
+        "//...": "--config=clang_linux",
+    },
+)

--- a/BUILD
+++ b/BUILD
@@ -322,9 +322,3 @@ cc_binary(
         "@stablehlo//:register",
     ],
 )
-
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
-
-buildifier(
-    name = "buildifier",
-)

--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ We welcome contributions to `mlir-tcp`. If you do contribute, please finalize yo
 find . -type f -name "*.cpp" -o -name "*.h" | xargs clang-format -i
 
 # buildifer
-bazel run //tools/buildifier:buildifier 
+bazel run //tools/buildifier:buildifier
 ```
 
 To enable clangd (for code completion, navigation and insights), generate the compilation database using [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor):
 ```shell
+bazel build //...
+
 bazel run //tools/clangd:refresh_compile_commands
 ```
 When run successfully, a `compile_commands.json` is generated at the workspace root (and refreshed upon re-runs). If you're using VSCode, just hit CMD+SHIFT+P and select `clangd: Restart language server` to start clangd. Note that this only works for non-docker builds at the moment.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ bazel run //:buildifier
 
 To enable clangd (for code completion, navigation and insights), generate the compilation database using [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor):
 ```shell
-bazel run --config=clang_linux //:refresh_compile_commands
+bazel run //tools/clangd:refresh_compile_commands
 ```
-When run successfully it prints `>>> Finished extracting commands for //:tcp-opt` and a `compile_commands.json` is generated at the project root. If you're using VSCode, just hit CMD+SHIFT+P and select `clangd: Restart language server` to start clangd. Note that this only works for non-docker builds at the moment.
+When run successfully, a `compile_commands.json` is generated at the workspace root (and refreshed upon re-runs). If you're using VSCode, just hit CMD+SHIFT+P and select `clangd: Restart language server` to start clangd. Note that this only works for non-docker builds at the moment.
 
 When bumping upstream dependencies (LLVM, Torch-MLIR, StableHLO), you may validate the set of "green commits" by running the corresponding third-party tests:
 ```shell

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We welcome contributions to `mlir-tcp`. If you do contribute, please finalize yo
 find . -type f -name "*.cpp" -o -name "*.h" | xargs clang-format -i
 
 # buildifer
-bazel run //:buildifier
+bazel run //tools/buildifier:buildifier 
 ```
 
 To enable clangd (for code completion, navigation and insights), generate the compilation database using [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor):

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ find . -type f -name "*.cpp" -o -name "*.h" | xargs clang-format -i
 bazel run //:buildifier
 ```
 
+To enable clangd (for code completion, navigation and insights), generate the compilation database using [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor):
+```shell
+bazel run --config=clang_linux //:refresh_compile_commands
+```
+When run successfully it prints `>>> Finished extracting commands for //:tcp-opt` and a `compile_commands.json` is generated at the project root. If you're using VSCode, just hit CMD+SHIFT+P and select `clangd: Restart language server` to start clangd. Note that this only works for non-docker builds at the moment.
+
 When bumping upstream dependencies (LLVM, Torch-MLIR, StableHLO), you may validate the set of "green commits" by running the corresponding third-party tests:
 ```shell
 bazel test @llvm-project//mlir/...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,36 +26,6 @@ torch_mlir_configure(name = "torch-mlir")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# ----------------------------- #
-#    Compile Commands Extractor #
-#    for Bazel (clangd)         #
-# ----------------------------- #
-
-# https://github.com/hedronvision/bazel-compile-commands-extractor/blob/main/README.md
-
-http_archive(
-    name = "hedron_compile_commands",
-    sha256 = "c6cab577506bf660fcdc572cffb0ed83aa3c2778de54886e6082766888dcc0cb",
-    strip_prefix = "bazel-compile-commands-extractor-f41ec092c76458374900242e0d6ed5e96f4e3a21",
-    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/f41ec092c76458374900242e0d6ed5e96f4e3a21.tar.gz",
-)
-
-load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
-
-hedron_compile_commands_setup()
-
-load("@hedron_compile_commands//:workspace_setup_transitive.bzl", "hedron_compile_commands_setup_transitive")
-
-hedron_compile_commands_setup_transitive()
-
-load("@hedron_compile_commands//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive")
-
-hedron_compile_commands_setup_transitive_transitive()
-
-load("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive_transitive")
-
-hedron_compile_commands_setup_transitive_transitive_transitive()
-
 # --------------------------- #
 #    Buildifier dependencies  #
 # --------------------------- #
@@ -113,3 +83,21 @@ http_archive(
         "https://github.com/bazelbuild/buildtools/archive/refs/tags/4.2.2.tar.gz",
     ],
 )
+
+# ----------------------------- #
+#    Compile Commands Extractor #
+#    for Bazel (clangd)         #
+# ----------------------------- #
+
+# https://github.com/hedronvision/bazel-compile-commands-extractor/blob/main/README.md
+
+http_archive(
+    name = "hedron_compile_commands",
+    sha256 = "2188c3cd3a16404a6b20136151b37e7afb5a320e150453750c15080de5ba3058",
+    strip_prefix = "bazel-compile-commands-extractor-6d58fa6bf39f612304e55566fa628fd160b38177",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/6d58fa6bf39f612304e55566fa628fd160b38177.tar.gz",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,11 +24,39 @@ load("@torch-mlir-raw//utils/bazel:configure.bzl", "torch_mlir_configure")
 
 torch_mlir_configure(name = "torch-mlir")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# --------------------------- #
+#    Clangd Compile Commands  #
+#    Extractor for Bazel      #
+# --------------------------- #
+
+http_archive(
+    name = "hedron_compile_commands",
+    sha256 = "c6cab577506bf660fcdc572cffb0ed83aa3c2778de54886e6082766888dcc0cb",
+    strip_prefix = "bazel-compile-commands-extractor-f41ec092c76458374900242e0d6ed5e96f4e3a21",
+    url = "https://github.com/hedronvision/bazel-compile-commands-extractor/archive/f41ec092c76458374900242e0d6ed5e96f4e3a21.tar.gz",
+)
+
+load("@hedron_compile_commands//:workspace_setup.bzl", "hedron_compile_commands_setup")
+
+hedron_compile_commands_setup()
+
+load("@hedron_compile_commands//:workspace_setup_transitive.bzl", "hedron_compile_commands_setup_transitive")
+
+hedron_compile_commands_setup_transitive()
+
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive")
+
+hedron_compile_commands_setup_transitive_transitive()
+
+load("@hedron_compile_commands//:workspace_setup_transitive_transitive_transitive.bzl", "hedron_compile_commands_setup_transitive_transitive_transitive")
+
+hedron_compile_commands_setup_transitive_transitive_transitive()
+
 # --------------------------- #
 #    Buildifier dependencies  #
 # --------------------------- #
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # buildifier is written in Go and hence needs rules_go to be built.
 # See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
@@ -60,8 +88,6 @@ http_archive(
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
-# If you use WORKSPACE.bazel, use the following line instead of the bare gazelle_dependencies():
-# gazelle_dependencies(go_repository_default_config = "@//:WORKSPACE.bazel")
 gazelle_dependencies()
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -26,10 +26,12 @@ torch_mlir_configure(name = "torch-mlir")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# --------------------------- #
-#    Clangd Compile Commands  #
-#    Extractor for Bazel      #
-# --------------------------- #
+# ----------------------------- #
+#    Compile Commands Extractor #
+#    for Bazel (clangd)         #
+# ----------------------------- #
+
+# https://github.com/hedronvision/bazel-compile-commands-extractor/blob/main/README.md
 
 http_archive(
     name = "hedron_compile_commands",
@@ -58,8 +60,8 @@ hedron_compile_commands_setup_transitive_transitive_transitive()
 #    Buildifier dependencies  #
 # --------------------------- #
 
-# buildifier is written in Go and hence needs rules_go to be built.
-# See https://github.com/bazelbuild/rules_go for the up to date setup instructions.
+# https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
+
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 
 # Install bazel
 ARG ARCH="x86_64"
-ARG BAZEL_VERSION=7.0.1
+ARG BAZEL_VERSION=6.4.0
 RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -O /usr/bin/bazel \
     && chmod a+x /usr/bin/bazel
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && \
 
 # Install bazel
 ARG ARCH="x86_64"
-ARG BAZEL_VERSION=5.4.0
+ARG BAZEL_VERSION=7.0.1
 RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-${ARCH} -O /usr/bin/bazel \
     && chmod a+x /usr/bin/bazel
 

--- a/tools/buildifier/BUILD
+++ b/tools/buildifier/BUILD
@@ -1,0 +1,5 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+)

--- a/tools/clangd/BUILD
+++ b/tools/clangd/BUILD
@@ -2,25 +2,25 @@ load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile
 
 refresh_compile_commands(
     name = "refresh_compile_commands",
-    # Targets obtained using the query:
+
+    # Keep this list updated by running the following query:
     #   bazel query 'kind("(cc.*) rule", //...)'
-    targets = {
-        "//:Pipeline": "--config=clang_linux",
-        "//:StablehloToTcp": "--config=clang_linux",
-        "//:TcpConversionPasses": "--config=clang_linux",
-        "//:TcpConversionPassesIncGen": "--config=clang_linux",
-        "//:TcpDialect": "--config=clang_linux",
-        "//:TcpDialectPasses": "--config=clang_linux",
-        "//:TcpDialectPassesIncGen": "--config=clang_linux",
-        "//:TcpInitAll": "--config=clang_linux",
-        "//:TcpOpsIncGen": "--config=clang_linux",
-        "//:TcpToArith": "--config=clang_linux",
-        "//:TcpToLinalg": "--config=clang_linux",
-        "//:TcpTypesIncGen": "--config=clang_linux",
-        "//:TorchToTcp": "--config=clang_linux",
-        "//:tcp-opt": "--config=clang_linux",
-        "//test:AotCompile/test_aot_compiled_basic_tcp_ops": "--config=clang_linux",
-        "//test:aot_compiled_basic_tcp_ops": "--config=clang_linux",
-        "//tools/aot:abi": "--config=clang_linux",
-    },
+    targets = [
+        "//:Pipeline",
+        "//:StablehloToTcp",
+        "//:TcpConversionPasses",
+        "//:TcpConversionPassesIncGen",
+        "//:TcpDialect",
+        "//:TcpDialectPasses",
+        "//:TcpDialectPassesIncGen",
+        "//:TcpInitAll",
+        "//:TcpOpsIncGen",
+        "//:TcpToArith",
+        "//:TcpToLinalg",
+        "//:TcpTypesIncGen",
+        "//:TorchToTcp",
+        "//:tcp-opt",
+        "//test:AotCompile/test_aot_compiled_basic_tcp_ops",
+        "//test:aot_compiled_basic_tcp_ops",
+    ],
 )

--- a/tools/clangd/BUILD
+++ b/tools/clangd/BUILD
@@ -1,0 +1,26 @@
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
+
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    # Targets obtained using the query:
+    #   bazel query 'kind("(cc.*) rule", //...)'
+    targets = {
+        "//:Pipeline": "--config=clang_linux",
+        "//:StablehloToTcp": "--config=clang_linux",
+        "//:TcpConversionPasses": "--config=clang_linux",
+        "//:TcpConversionPassesIncGen": "--config=clang_linux",
+        "//:TcpDialect": "--config=clang_linux",
+        "//:TcpDialectPasses": "--config=clang_linux",
+        "//:TcpDialectPassesIncGen": "--config=clang_linux",
+        "//:TcpInitAll": "--config=clang_linux",
+        "//:TcpOpsIncGen": "--config=clang_linux",
+        "//:TcpToArith": "--config=clang_linux",
+        "//:TcpToLinalg": "--config=clang_linux",
+        "//:TcpTypesIncGen": "--config=clang_linux",
+        "//:TorchToTcp": "--config=clang_linux",
+        "//:tcp-opt": "--config=clang_linux",
+        "//test:AotCompile/test_aot_compiled_basic_tcp_ops": "--config=clang_linux",
+        "//test:aot_compiled_basic_tcp_ops": "--config=clang_linux",
+        "//tools/aot:abi": "--config=clang_linux",
+    },
+)


### PR DESCRIPTION
Uses [bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor) to generate the compilation database from our bazel build. 

Other minor improvements include:
- simplify .bazelrc
- move buildifier and compile-commands-extractor targets to separate `tools/` to make downstream integrations easier (else they fail on loading these deps)
- bump bazel to 6.4.0 (for `--noenable_bzlmod` option)