### PR TITLE
[Build] Switch all docker flows to run as user (non-root)

### DIFF
--- a/.github/workflows/bazelBuildAndTestLlvm.yml
+++ b/.github/workflows/bazelBuildAndTestLlvm.yml
@@ -48,35 +48,20 @@ jobs:
         restore-keys: |
           llvm-project-bazel-build-cache-${{ runner.os }}
 
-    # Change bazel cache directory to root ownership
-    # to allow writing to it from within the docker container.
-    # If no cache hits, this directory is not present
-    # so don't run chown (will error otherwise).
-    - name: Set bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R root:root "${HOME}/.cache/bazel"
-        fi
-
     - name: Build docker image
       run: |
         docker build -f docker/Dockerfile \
                      -t mlir-tcp:ci \
+                     --build-arg GROUP=$(id -gn) \
+                     --build-arg GID=$(id -g) \
+                     --build-arg USER=$(id -un) \
+                     --build-arg UID=$(id -u) \
                      .
 
     - name: Bazel build and test llvm-project
       run: |
         docker run --rm \
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
-                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
                    bazel test --config=clang_linux @llvm-project//mlir/...
-
-    # Switch back bazel cache directory to user ownership
-    # to allow GHA post-cache step to save cache without
-    # permissions issue.
-    - name: Switch bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R "$USER":"$USER" "${HOME}/.cache/bazel"
-        fi

--- a/.github/workflows/bazelBuildAndTestStablehlo.yml
+++ b/.github/workflows/bazelBuildAndTestStablehlo.yml
@@ -48,35 +48,20 @@ jobs:
         restore-keys: |
           stablehlo-bazel-build-cache-${{ runner.os }}
 
-    # Change bazel cache directory to root ownership
-    # to allow writing to it from within the docker container.
-    # If no cache hits, this directory is not present
-    # so don't run chown (will error otherwise).
-    - name: Set bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R root:root "${HOME}/.cache/bazel"
-        fi
-
     - name: Build docker image
       run: |
         docker build -f docker/Dockerfile \
                      -t mlir-tcp:ci \
+                     --build-arg GROUP=$(id -gn) \
+                     --build-arg GID=$(id -g) \
+                     --build-arg USER=$(id -un) \
+                     --build-arg UID=$(id -u) \
                      .
 
     - name: Bazel build and test stablehlo
       run: |
         docker run --rm \
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
-                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
                    bazel test --config=clang_linux @stablehlo//...
-
-    # Switch back bazel cache directory to user ownership
-    # to allow GHA post-cache step to save cache without
-    # permissions issue.
-    - name: Switch bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R "$USER":"$USER" "${HOME}/.cache/bazel"
-        fi

--- a/.github/workflows/bazelBuildAndTestTcp.yml
+++ b/.github/workflows/bazelBuildAndTestTcp.yml
@@ -43,27 +43,21 @@ jobs:
         restore-keys: |
           mlir-tcp-bazel-build-cache-${{ runner.os }}
 
-    # Change bazel cache directory to root ownership
-    # to allow writing to it from within the docker container.
-    # If no cache hits, this directory is not present
-    # so don't run chown (will error otherwise).
-    - name: Set bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R root:root "${HOME}/.cache/bazel"
-        fi
-
     - name: Build docker image
       run: |
         docker build -f docker/Dockerfile \
                      -t mlir-tcp:ci \
+                     --build-arg GROUP=$(id -gn) \
+                     --build-arg GID=$(id -g) \
+                     --build-arg USER=$(id -un) \
+                     --build-arg UID=$(id -u) \
                      .
 
     - name: Verify clang-format was run (cpp lint)
       run: |
         docker run --rm \
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
-                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
                    find . -type f -name "*.cpp" -o -name "*.h" | xargs clang-format -i
         if [ -n "$(git status --porcelain)" ]; then
@@ -75,11 +69,11 @@ jobs:
       run: |
         docker run --rm \
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
-                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
                    bazel run --config=clang_linux //:buildifier
         if [ -n "$(git status --porcelain)" ]; then
-          echo "Please 'bazel run //:buildifier' and commit changes."
+          echo "Please 'bazel run --config=clang_linux //:buildifier' and commit changes."
           exit 1
         fi
 
@@ -87,7 +81,7 @@ jobs:
       run: |
         docker run --rm \
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
-                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
                    bazel build --config=clang_linux //:tcp-opt
 
@@ -95,15 +89,6 @@ jobs:
       run: |
         docker run --rm \
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
-                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
                    bazel test --config=clang_linux //test/...
-
-    # Switch back bazel cache directory to user ownership
-    # to allow GHA post-cache step to save cache without
-    # permissions issue.
-    - name: Switch bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R "$USER":"$USER" "${HOME}/.cache/bazel"
-        fi

--- a/.github/workflows/bazelBuildAndTestTorchmlir.yml
+++ b/.github/workflows/bazelBuildAndTestTorchmlir.yml
@@ -48,35 +48,20 @@ jobs:
         restore-keys: |
           torch-mlir-bazel-build-cache-${{ runner.os }}
 
-    # Change bazel cache directory to root ownership
-    # to allow writing to it from within the docker container.
-    # If no cache hits, this directory is not present
-    # so don't run chown (will error otherwise).
-    - name: Set bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R root:root "${HOME}/.cache/bazel"
-        fi
-
     - name: Build docker image
       run: |
         docker build -f docker/Dockerfile \
                      -t mlir-tcp:ci \
+                     --build-arg GROUP=$(id -gn) \
+                     --build-arg GID=$(id -g) \
+                     --build-arg USER=$(id -un) \
+                     --build-arg UID=$(id -u) \
                      .
 
     - name: Bazel build and test torch-mlir
       run: |
         docker run --rm \
                    -v "$(pwd)":"/opt/src/mlir-tcp" \
-                   -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+                   -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
                    mlir-tcp:ci \
                    bazel test --config=clang_linux @torch-mlir//...
-
-    # Switch back bazel cache directory to user ownership
-    # to allow GHA post-cache step to save cache without
-    # permissions issue.
-    - name: Switch bazel cache permissions
-      run: |
-        if [ -d "${HOME}/.cache/bazel" ]; then
-          sudo chown -R "$USER":"$USER" "${HOME}/.cache/bazel"
-        fi

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,7 +10,6 @@ load("//:deps.bzl", "third_party_deps")
 third_party_deps()
 
 load("@llvm-raw//utils/bazel:configure.bzl", "llvm_configure")
-load("@torch-mlir-raw//utils/bazel:configure.bzl", "torch_mlir_configure")
 
 llvm_configure(
     name = "llvm-project",
@@ -20,6 +19,8 @@ llvm_configure(
         "AArch64",
     ],
 )
+
+load("@torch-mlir-raw//utils/bazel:configure.bzl", "torch_mlir_configure")
 
 torch_mlir_configure(name = "torch-mlir")
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get clean \
 # Set workdir before launching container
 WORKDIR /opt/src/mlir-tcp
 
-# Add user
+# Add user permissions
 RUN groupadd -o -g ${GID} ${GROUP} && \
     useradd -u ${UID} -g ${GROUP} -ms /bin/bash ${USER} && \
     usermod -aG sudo ${USER} && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,15 @@
 ARG BASE_IMG=ubuntu:22.04
 FROM ${BASE_IMG} as dev-base
 
+# Specify user IDs
+ARG GROUP
+ARG GID
+ARG USER
+ARG UID
+
+# Run below commands as root
+USER root
+
 # Install basic packages
 RUN apt-get update && \
     apt-get install -y \
@@ -25,4 +34,14 @@ RUN wget -q https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSIO
 RUN apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# Set workdir before launching container
 WORKDIR /opt/src/mlir-tcp
+
+# Add user
+RUN groupadd -o -g ${GID} ${GROUP} && \
+    useradd -u ${UID} -g ${GROUP} -ms /bin/bash ${USER} && \
+    usermod -aG sudo ${USER} && \
+    chown -R ${USER}:${GROUP} /opt/src/mlir-tcp
+
+# Switch to user
+USER ${USER}

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -2,9 +2,13 @@
 
 docker build -f docker/Dockerfile \
              -t mlir-tcp:dev \
+             --build-arg GROUP=$(id -gn) \
+             --build-arg GID=$(id -g) \
+             --build-arg USER=$(id -un) \
+             --build-arg UID=$(id -u) \
              .
 
 docker run -it \
            -v "$(pwd)":"/opt/src/mlir-tcp" \
-           -v "${HOME}/.cache/bazel":"/root/.cache/bazel" \
+           -v "${HOME}/.cache/bazel":"${HOME}/.cache/bazel" \
            mlir-tcp:dev


### PR DESCRIPTION
Running docker as root has unintended side effects such as clobbering of user space with root-modified files (e.g. when clang-format or buildifier was run from within docker). This also creates permission issues when generating compilation database (for clangd). Another side benefit of this is we no longer need the patches to our GHA/CI workflows to update bazel cache permissions before / after the builds.