### PR TITLE
Disable third party builds (on push to main) until we migrate to self-hosted runners

### DIFF
--- a/.github/workflows/bazelBuildAndTestLlvm.yml
+++ b/.github/workflows/bazelBuildAndTestLlvm.yml
@@ -13,12 +13,13 @@ on:
     paths:
       - 'deps.bzl'
       - '.github/workflows/bazelBuildAndTestLlvm.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'deps.bzl'
-      - '.github/workflows/bazelBuildAndTestLlvm.yml'
+  # TODO: Use self-hosted runners as we hit disk space issues with GitHub hosted runners
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'deps.bzl'
+  #     - '.github/workflows/bazelBuildAndTestLlvm.yml'
   workflow_dispatch:
 
 # Ensure that only a single job or workflow using the same

--- a/.github/workflows/bazelBuildAndTestStablehlo.yml
+++ b/.github/workflows/bazelBuildAndTestStablehlo.yml
@@ -13,12 +13,13 @@ on:
     paths:
       - 'deps.bzl'
       - '.github/workflows/bazelBuildAndTestStablehlo.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'deps.bzl'
-      - '.github/workflows/bazelBuildAndTestStablehlo.yml'
+  # TODO: Use self-hosted runners as we hit disk space issues with GitHub hosted runners
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'deps.bzl'
+  #     - '.github/workflows/bazelBuildAndTestStablehlo.yml'
   workflow_dispatch:
 
 # Ensure that only a single job or workflow using the same

--- a/.github/workflows/bazelBuildAndTestTorchmlir.yml
+++ b/.github/workflows/bazelBuildAndTestTorchmlir.yml
@@ -13,12 +13,13 @@ on:
     paths:
       - 'deps.bzl'
       - '.github/workflows/bazelBuildAndTestTorchmlir.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'deps.bzl'
-      - '.github/workflows/bazelBuildAndTestTorchmlir.yml'
+  # TODO: Use self-hosted runners as we hit disk space issues with GitHub hosted runners
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'deps.bzl'
+  #     - '.github/workflows/bazelBuildAndTestTorchmlir.yml'
   workflow_dispatch:
 
 # Ensure that only a single job or workflow using the same


### PR DESCRIPTION
We're hitting `no space left on device` errors during llvm and stablehlo builds with the free GitHub hosted runners, which come with limited disk space allocations. Cleaning up the runners as recommended [here](https://github.com/orgs/community/discussions/25678), [here](https://github.com/orgs/community/discussions/26351) and https://github.com/actions/runner-images/issues/2875 have helped partially (increase root mount from 20G to 47G) but it still isn't enough for some builds. Temporarily disable the 3p builds on push to main (they will still run as non-merge gating on PRs), and re-enable once self-hosted runners are setup.