### PR TITLE
Move AotCompile to its own BUILD

### DIFF
--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -1,0 +1,28 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+load("//tools/aot:aot_compile.bzl", "aot_compile")
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+aot_compile(
+    name = "basic_tcp_ops",
+    tcp_source = "basic_tcp_ops.mlir",
+)
+
+cc_test(
+    name = "test_aot_compiled_basic_tcp_ops",
+    srcs = ["test_aot_compiled_basic_tcp_ops.cpp"],
+    tags = ["aot_tests"],
+    deps = [
+        ":aot_compiled_basic_tcp_ops",
+        "//tools/aot:abi",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+test_suite(
+    name = "aot_tests",
+    tags = ["aot_tests"],
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -5,8 +5,6 @@
 
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@llvm-project//llvm:lit_test.bzl", "lit_test")
-load("//tools/aot:aot_compile.bzl", "aot_compile")
-load("@rules_cc//cc:defs.bzl", "cc_test")
 load("@pip_deps//:requirements.bzl", "requirement")
 
 expand_template(
@@ -59,37 +57,16 @@ filegroup(
     ])
 ]
 
-aot_compile(
-    name = "basic_tcp_ops",
-    tcp_source = "AotCompile/basic_tcp_ops.mlir",
-)
-
-cc_test(
-    name = "AotCompile/test_aot_compiled_basic_tcp_ops",
-    srcs = ["AotCompile/test_aot_compiled_basic_tcp_ops.cpp"],
-    tags = ["aot_tests"],
-    deps = [
-        ":aot_compiled_basic_tcp_ops",
-        "//tools/aot:abi",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
 test_suite(
     name = "lit_tests",
     tags = ["lit_tests"],
 )
 
 test_suite(
-    name = "aot_tests",
-    tags = ["aot_tests"],
-)
-
-test_suite(
     name = "all_tests",
     tests = [
-        "//test:aot_tests",
         "//test:lit_tests",
+        "//test/AotCompile:aot_tests",
         "//test/python:python_tests",
     ],
 )

--- a/tools/clangd/BUILD
+++ b/tools/clangd/BUILD
@@ -25,7 +25,7 @@ refresh_compile_commands(
         "//:TcpTypesIncGen",
         "//:TorchToTcp",
         "//:tcp-opt",
-        "//test:AotCompile/test_aot_compiled_basic_tcp_ops",
-        "//test:aot_compiled_basic_tcp_ops",
+        "//test/AotCompile:aot_compiled_basic_tcp_ops",
+        "//test/AotCompile:test_aot_compiled_basic_tcp_ops",
     ],
 )

--- a/tools/clangd/BUILD
+++ b/tools/clangd/BUILD
@@ -25,7 +25,5 @@ refresh_compile_commands(
         "//:TcpTypesIncGen",
         "//:TorchToTcp",
         "//:tcp-opt",
-        "//test/AotCompile:aot_compiled_basic_tcp_ops",
-        "//test/AotCompile:test_aot_compiled_basic_tcp_ops",
     ],
 )


### PR DESCRIPTION
Keeps the main test/BUILD specific to LIT, and allows (as a follow-on) expanding AotCompile into e2e integration style tests for TCP based compilations.