### PR TITLE
[AOT Compile] Use `StridedMemRefType` descriptor from upstream mlir/CRunnerUtils.h

### DIFF
--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -19,6 +19,7 @@ cc_test(
         ":aot_compiled_basic_tcp_ops",
         "//tools/aot:abi",
         "@com_google_googletest//:gtest_main",
+        "@llvm-project//mlir:mlir_c_runner_utils_hdrs",
     ],
 )
 

--- a/test/AotCompile/test_aot_compiled_basic_tcp_ops.cpp
+++ b/test/AotCompile/test_aot_compiled_basic_tcp_ops.cpp
@@ -12,7 +12,6 @@
 
 #include "gtest/gtest.h"
 
-using namespace mlir;
 using namespace mlir::tcp;
 
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"

--- a/test/AotCompile/test_aot_compiled_basic_tcp_ops.cpp
+++ b/test/AotCompile/test_aot_compiled_basic_tcp_ops.cpp
@@ -7,27 +7,29 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/ExecutionEngine/CRunnerUtils.h"
 #include "tools/aot/abi.h"
 
 #include "gtest/gtest.h"
 
+using namespace mlir;
 using namespace mlir::tcp;
 
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 
-extern "C" RankedMemref<float, 2> func_1(DECL_RANK_2_MEMREF_ABI(float),
-                                         DECL_RANK_2_MEMREF_ABI(float),
-                                         DECL_RANK_2_MEMREF_ABI(float));
+extern "C" StridedMemRefType<float, 2> func_1(DECL_RANK_2_MEMREF_ABI(float),
+                                              DECL_RANK_2_MEMREF_ABI(float),
+                                              DECL_RANK_2_MEMREF_ABI(float));
 
-static RankedMemref<float, 2> CreateRank2Memref(float *Ptr) {
-  RankedMemref<float, 2> Result;
-  Result.AllocatedPointer = Ptr;
-  Result.AlignedPointer = Ptr;
-  Result.Offset = 0;
-  Result.Sizes[0] = 2;
-  Result.Sizes[1] = 3;
-  Result.Strides[0] = 3;
-  Result.Strides[1] = 1;
+static StridedMemRefType<float, 2> CreateRank2Memref(float *Ptr) {
+  StridedMemRefType<float, 2> Result;
+  Result.basePtr = Ptr;
+  Result.data = Ptr;
+  Result.offset = 0;
+  Result.sizes[0] = 2;
+  Result.sizes[1] = 3;
+  Result.strides[0] = 3;
+  Result.strides[1] = 1;
 
   return Result;
 }
@@ -44,31 +46,31 @@ TEST(AotCompiled, SingleOutput) {
       Arr3[i][j] = 3 + j;
     }
 
-  RankedMemref<float, 2> Input1 = CreateRank2Memref(&Arr1[0][0]);
-  RankedMemref<float, 2> Input2 = CreateRank2Memref(&Arr2[0][0]);
-  RankedMemref<float, 2> Input3 = CreateRank2Memref(&Arr3[0][0]);
+  StridedMemRefType<float, 2> Input1 = CreateRank2Memref(&Arr1[0][0]);
+  StridedMemRefType<float, 2> Input2 = CreateRank2Memref(&Arr2[0][0]);
+  StridedMemRefType<float, 2> Input3 = CreateRank2Memref(&Arr3[0][0]);
 
-  RankedMemref<float, 2> Result =
+  StridedMemRefType<float, 2> Result =
       func_1(PASS_RANK_2_MEMREF(Input1), PASS_RANK_2_MEMREF(Input2),
              PASS_RANK_2_MEMREF(Input3));
 
-  ASSERT_EQ(Result.Sizes[0], 2);
-  ASSERT_EQ(Result.Sizes[1], 3);
-  ASSERT_EQ(Result.Strides[0], 3);
-  ASSERT_EQ(Result.Strides[1], 1);
+  ASSERT_EQ(Result.sizes[0], 2);
+  ASSERT_EQ(Result.sizes[1], 3);
+  ASSERT_EQ(Result.strides[0], 3);
+  ASSERT_EQ(Result.strides[1], 1);
 
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 3; j++) {
       float Expected = (5 + (2 + i)) * (3 + j);
-      EXPECT_EQ(Result.AlignedPointer[3 * i + j], Expected);
+      EXPECT_EQ(Result.data[3 * i + j], Expected);
     }
 
-  free(Result.AllocatedPointer);
+  free(Result.basePtr);
 }
 
 struct TwoMemRefs {
-  RankedMemref<float, 2> A;
-  RankedMemref<float, 2> B;
+  StridedMemRefType<float, 2> A;
+  StridedMemRefType<float, 2> B;
 };
 
 extern "C" TwoMemRefs func_2(DECL_RANK_2_MEMREF_ABI(float),
@@ -87,50 +89,51 @@ TEST(AotCompiled, MultiOutput) {
       Arr3[i][j] = 3 + j;
     }
 
-  RankedMemref<float, 2> Input1 = CreateRank2Memref(&Arr1[0][0]);
-  RankedMemref<float, 2> Input2 = CreateRank2Memref(&Arr2[0][0]);
-  RankedMemref<float, 2> Input3 = CreateRank2Memref(&Arr3[0][0]);
+  StridedMemRefType<float, 2> Input1 = CreateRank2Memref(&Arr1[0][0]);
+  StridedMemRefType<float, 2> Input2 = CreateRank2Memref(&Arr2[0][0]);
+  StridedMemRefType<float, 2> Input3 = CreateRank2Memref(&Arr3[0][0]);
 
   TwoMemRefs Result =
       func_2(PASS_RANK_2_MEMREF(Input1), PASS_RANK_2_MEMREF(Input2),
              PASS_RANK_2_MEMREF(Input3));
 
-  ASSERT_EQ(Result.A.Sizes[0], 2);
-  ASSERT_EQ(Result.A.Sizes[1], 3);
-  ASSERT_EQ(Result.A.Strides[0], 3);
-  ASSERT_EQ(Result.A.Strides[1], 1);
+  ASSERT_EQ(Result.A.sizes[0], 2);
+  ASSERT_EQ(Result.A.sizes[1], 3);
+  ASSERT_EQ(Result.A.strides[0], 3);
+  ASSERT_EQ(Result.A.strides[1], 1);
 
-  ASSERT_EQ(Result.B.Sizes[0], 2);
-  ASSERT_EQ(Result.B.Sizes[1], 3);
-  ASSERT_EQ(Result.B.Strides[0], 3);
-  ASSERT_EQ(Result.B.Strides[1], 1);
+  ASSERT_EQ(Result.B.sizes[0], 2);
+  ASSERT_EQ(Result.B.sizes[1], 3);
+  ASSERT_EQ(Result.B.strides[0], 3);
+  ASSERT_EQ(Result.B.strides[1], 1);
 
   for (int i = 0; i < 2; i++)
     for (int j = 0; j < 3; j++) {
       float ExpectedA = 5 + (2 + i);
-      EXPECT_EQ(Result.A.AlignedPointer[3 * i + j], ExpectedA);
+      EXPECT_EQ(Result.A.data[3 * i + j], ExpectedA);
 
       float ExpectedB = ExpectedA * (3 + j);
-      EXPECT_EQ(Result.B.AlignedPointer[3 * i + j], ExpectedB);
+      EXPECT_EQ(Result.B.data[3 * i + j], ExpectedB);
     }
 
-  free(Result.A.AllocatedPointer);
-  free(Result.B.AllocatedPointer);
+  free(Result.A.basePtr);
+  free(Result.B.basePtr);
 }
 
-extern "C" RankedMemref<float, 1> func_3(DECL_RANK_0_MEMREF_ABI(float),
-                                         DECL_RANK_1_MEMREF_ABI(float));
+extern "C" StridedMemRefType<float, 1> func_3(DECL_RANK_0_MEMREF_ABI(float),
+                                              DECL_RANK_1_MEMREF_ABI(float));
 
 TEST(AotCompiled, MixedRanks) {
   float Arr0 = 10.0;
   float Arr1[2] = {1.0, 2.0};
 
-  RankedMemref<float, 1> Result = func_3(&Arr0, &Arr0, 0, Arr1, Arr1, 0, 2, 1);
+  StridedMemRefType<float, 1> Result =
+      func_3(&Arr0, &Arr0, 0, Arr1, Arr1, 0, 2, 1);
 
-  EXPECT_EQ(Result.Sizes[0], 2);
-  EXPECT_EQ(Result.Strides[0], 1);
-  EXPECT_EQ(Result.AlignedPointer[0], 11.0);
-  EXPECT_EQ(Result.AlignedPointer[1], 12.0);
+  EXPECT_EQ(Result.sizes[0], 2);
+  EXPECT_EQ(Result.strides[0], 1);
+  EXPECT_EQ(Result.data[0], 11.0);
+  EXPECT_EQ(Result.data[1], 12.0);
 
-  free(Result.AllocatedPointer);
+  free(Result.basePtr);
 }

--- a/tools/aot/abi.h
+++ b/tools/aot/abi.h
@@ -30,6 +30,7 @@ using IndexTy = long;
 //
 // StridedMemRefType is described at
 // https://mlir.llvm.org/docs/TargetLLVMIR/#ranked-memref-types
+// and defined at
 // https://sourcegraph.com/github.com/llvm/llvm-project@b5048700fc31f3bf6dd32ace7730815d4cfef411/-/blob/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h?L131
 
 #define DECL_RANK_2_MEMREF_ABI(data_type)                                      \

--- a/tools/aot/abi.h
+++ b/tools/aot/abi.h
@@ -24,18 +24,13 @@ using IndexTy = long;
 // where Output is defined as:
 //
 // struct Output {
-//   RankedMemref<float, 2> A;
-//   RankedMemref<float, 3> B;
+//   StridedMemRefType<float, 2> A;
+//   StridedMemRefType<float, 3> B;
 // };
-
-template <typename DataType, int Rank> struct RankedMemref {
-  // Described at https://mlir.llvm.org/docs/TargetLLVMIR/#ranked-memref-types
-  DataType *AllocatedPointer;
-  DataType *AlignedPointer;
-  IndexTy Offset;
-  IndexTy Sizes[Rank];
-  IndexTy Strides[Rank];
-};
+//
+// StridedMemRefType is described at
+// https://mlir.llvm.org/docs/TargetLLVMIR/#ranked-memref-types
+// https://sourcegraph.com/github.com/llvm/llvm-project@b5048700fc31f3bf6dd32ace7730815d4cfef411/-/blob/mlir/include/mlir/ExecutionEngine/CRunnerUtils.h?L131
 
 #define DECL_RANK_2_MEMREF_ABI(data_type)                                      \
   data_type *, data_type *, IndexTy, IndexTy, IndexTy, IndexTy, IndexTy
@@ -47,14 +42,13 @@ template <typename DataType, int Rank> struct RankedMemref {
 // passing to an AOT compiled function.
 
 #define PASS_RANK_2_MEMREF(memref)                                             \
-  (memref).AllocatedPointer, (memref).AlignedPointer, (memref).Offset,         \
-      (memref).Sizes[0], (memref).Sizes[1], (memref).Strides[0],               \
-      (memref).Strides[1]
+  (memref).basePtr, (memref).data, (memref).offset, (memref).sizes[0],         \
+      (memref).sizes[1], (memref).strides[0], (memref).strides[1]
 #define PASS_RANK_1_MEMREF(memref)                                             \
-  (memref).AllocatedPointer, (memref).AlignedPointer, (memref).Offset,         \
-      (memref).Sizes[0], (memref).Strides[0],
+  (memref).basePtr, (memref).data, (memref).offset, (memref).sizes[0],         \
+      (memref).strides[0],
 #define PASS_RANK_0_MEMREF(memref)                                             \
-  (memref).AllocatedPointer, (memref).AlignedPointer, (memref).Offset
+  (memref).basePtr, (memref).data, (memref).offset
 
 } // namespace tcp
 } // namespace mlir


### PR DESCRIPTION
As titled.