### PR TITLE
[AOT] Add tensor slicing to the aot_compile suite

### DIFF
--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -55,6 +55,12 @@ aot_compile(
 )
 
 aot_compile(
+    name = "slice_tensor",
+    torch_loader_lib = ":model_loader_lib",
+    torch_loader_path = "test.AotCompile.model_loader_lib.slice_tensor_loader",
+)
+
+aot_compile(
     name = "basic_tcp_ops",
     tcp_source = "basic_tcp_ops.mlir",
 )

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -172,3 +172,26 @@ def concat_int_tensors_loader() -> TorchLoaderOutput:
         inputs=[x, y],
         constraints=constraints,
     )
+
+
+def slice_tensor_loader() -> TorchLoaderOutput:
+    class SliceTensor(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return x[0:2, :1]
+
+    # Sample inputs
+    x = torch.randn(4, 3)
+
+    # Dynamic dim constraints
+    constraints = [
+        dynamic_dim(x, 0) > 2,
+    ]
+
+    return TorchLoaderOutput(
+        model=SliceTensor(),
+        inputs=[x],
+        constraints=constraints,
+    )


### PR DESCRIPTION
For the included tensor slice example, this is the Dynamo exported Torch dialect:
```ll
module {                                                                                                                                                 
  func.func @func_main(%arg0: !torch.vtensor<[?,3],f32>) -> !torch.vtensor<[2,1],f32> {                                                                  
    %int0 = torch.constant.int 0                                                                                                                         
    %int0_0 = torch.constant.int 0                                                                                                                       
    %int2 = torch.constant.int 2                                                                                                                         
    %int1 = torch.constant.int 1                                                                                                                         
    %0 = torch.aten.slice.Tensor %arg0, %int0, %int0_0, %int2, %int1 : !torch.vtensor<[?,3],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[2,3],f32>                                                                                                                                     
    %int1_1 = torch.constant.int 1                                                                                                                       
    %int0_2 = torch.constant.int 0                                                                                                                       
    %int1_3 = torch.constant.int 1                                                                                                                       
    %int1_4 = torch.constant.int 1                                                                                                                       
    %1 = torch.aten.slice.Tensor %0, %int1_1, %int0_2, %int1_3, %int1_4 : !torch.vtensor<[2,3],f32>, !torch.int, !torch.int, !torch.int, !torch.int -> !torch.vtensor<[2,1],f32>                                                                                                                                  
    return %1 : !torch.vtensor<[2,1],f32>                                                                                                                
  }                                                                                                                                                      
}    
```
and the TCP program using `tensor.extract_slice`s and a bunch of arith ops for indexing:
```ll
module {                                                                                                                                                 
  func.func @func_main(%arg0: tensor<?x3xf32>) -> tensor<2x1xf32> {                                                                                      
    %c0 = arith.constant 0 : index                                                                                                                       
    %c0_i64 = arith.constant 0 : i64                                                                                                                     
    %dim = tensor.dim %arg0, %c0 : tensor<?x3xf32>                                                                                                       
    %0 = arith.index_cast %dim : index to i64                                                                                                            
    %1 = arith.cmpi slt, %0, %c0_i64 : i64                                                                                                               
    %2 = arith.select %1, %0, %c0_i64 : i64                                                                                                              
    %3 = arith.index_cast %2 : i64 to index                                                                                                              
    %extracted_slice = tensor.extract_slice %arg0[%3, 0] [2, 3] [1, 1] : tensor<?x3xf32> to tensor<2x3xf32>                                              
    %extracted_slice_0 = tensor.extract_slice %extracted_slice[0, 0] [2, 1] [1, 1] : tensor<2x3xf32> to tensor<2x1xf32>                                  
    return %extracted_slice_0 : tensor<2x1xf32>                                                                                                          
  }                                                                                                                                                      
} 
```
LLVM IRs and host assembly are not shown but the e2e execute test works! 
