### PR TITLE
TcpToLinalg legality fixes: Mark only the Tcp ops with conversions as illegal

### DIFF
--- a/lib/Conversion/StablehloToTcp/StablehloToTcp.cpp
+++ b/lib/Conversion/StablehloToTcp/StablehloToTcp.cpp
@@ -22,7 +22,7 @@
 
 namespace mlir {
 
-#define GEN_PASS_DEF_CONVERTTCPTOLINALG
+#define GEN_PASS_DEF_CONVERTSTABLEHLOTOTCP
 #include "mlir-tcp/Conversion/Passes.h.inc"
 
 namespace tcp {

--- a/lib/Conversion/TcpToArith/TcpToArith.cpp
+++ b/lib/Conversion/TcpToArith/TcpToArith.cpp
@@ -22,7 +22,7 @@
 
 namespace mlir {
 
-#define GEN_PASS_DEF_CONVERTTCPTOLINALG
+#define GEN_PASS_DEF_CONVERTTCPTOARITH
 #include "mlir-tcp/Conversion/Passes.h.inc"
 
 namespace tcp {
@@ -40,8 +40,10 @@ public:
   }
 };
 
-void populateTcpToArithConversionPatterns(RewritePatternSet *patterns) {
-  patterns->add<ConstOpConverter>(patterns->getContext());
+void populateTcpToArithConversionPatterns(RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+
+  patterns.add<ConstOpConverter>(context);
 }
 
 class ConvertTcpToArith : public ConvertTcpToArithBase<ConvertTcpToArith> {
@@ -55,7 +57,7 @@ public:
     typeConverter.addConversion([](Type type) { return type; });
 
     RewritePatternSet patterns(context);
-    populateTcpToArithConversionPatterns(&patterns);
+    populateTcpToArithConversionPatterns(patterns);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))

--- a/lib/Conversion/TcpToLinalg/Elementwise.cpp
+++ b/lib/Conversion/TcpToLinalg/Elementwise.cpp
@@ -315,23 +315,26 @@ void mlir::TcpToLinalg::populateElementwisePatternsAndLegality(
     ConversionTarget &target) {
   MLIRContext *context = patterns.getContext();
 
-  target.addIllegalDialect<TcpDialect>();
-  patterns.add<ConvertElementwiseOp<AddOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<ClampOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<MulOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<DivFOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<SubOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<TanhOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<SigmoidOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<SqrtOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<CeilOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<FloorOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<SinOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<CosOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<AbsOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<LogOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<NegOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<AtanOp>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<Atan2Op>>(typeConverter, context);
-  patterns.add<ConvertElementwiseOp<CastOp>>(typeConverter, context);
+#define INSERT_TCP_TO_LINALG_PATTERN(TcpOp)                                    \
+  target.addIllegalOp<TcpOp>();                                                \
+  patterns.add<ConvertElementwiseOp<TcpOp>>(typeConverter, context);
+  INSERT_TCP_TO_LINALG_PATTERN(AddOp);
+  INSERT_TCP_TO_LINALG_PATTERN(ClampOp);
+  INSERT_TCP_TO_LINALG_PATTERN(MulOp);
+  INSERT_TCP_TO_LINALG_PATTERN(DivFOp);
+  INSERT_TCP_TO_LINALG_PATTERN(SubOp);
+  INSERT_TCP_TO_LINALG_PATTERN(TanhOp);
+  INSERT_TCP_TO_LINALG_PATTERN(SigmoidOp);
+  INSERT_TCP_TO_LINALG_PATTERN(SqrtOp);
+  INSERT_TCP_TO_LINALG_PATTERN(CeilOp);
+  INSERT_TCP_TO_LINALG_PATTERN(FloorOp);
+  INSERT_TCP_TO_LINALG_PATTERN(SinOp);
+  INSERT_TCP_TO_LINALG_PATTERN(CosOp);
+  INSERT_TCP_TO_LINALG_PATTERN(AbsOp);
+  INSERT_TCP_TO_LINALG_PATTERN(LogOp);
+  INSERT_TCP_TO_LINALG_PATTERN(NegOp);
+  INSERT_TCP_TO_LINALG_PATTERN(AtanOp);
+  INSERT_TCP_TO_LINALG_PATTERN(Atan2Op);
+  INSERT_TCP_TO_LINALG_PATTERN(CastOp);
+#undef INSERT_TCP_TO_LINALG_PATTERN
 }

--- a/test/Conversion/TcpToLinalg/misc.mlir
+++ b/test/Conversion/TcpToLinalg/misc.mlir
@@ -55,9 +55,8 @@ func.func @broadcast_4D(%arg0 : tensor<?x1x?x1xf32>, %arg1 : index, %arg2 : inde
 
 // -----
 
-// tcp.const is not converted by TcpToLinalg, but this test ensures
-// it goes through without failing legalization, and that TcpToLinalg
-// doesn't mark TcpDialect is illegal.
+// tcp.const is not converted by TcpToLinalg, but this test ensures it goes through
+// without failing legalization, and that TcpToLinalg doesn't mark TcpDialect is illegal.
 
 // CHECK-LABEL: func.func @test_constants() -> tensor<f32> {
 // CHECK:         tcp.const {value = dense<2.500000e+00> : tensor<f32>} : tensor<f32>

--- a/test/Conversion/TcpToLinalg/misc.mlir
+++ b/test/Conversion/TcpToLinalg/misc.mlir
@@ -52,3 +52,16 @@ func.func @broadcast_4D(%arg0 : tensor<?x1x?x1xf32>, %arg1 : index, %arg2 : inde
   %0 = "tcp.broadcast"(%arg0, %arg1, %arg2) {axes = [1, 3]} : (tensor<?x1x?x1xf32>, index, index) -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
 }
+
+// -----
+
+// tcp.const is not converted by TcpToLinalg, but this test ensures
+// it goes through without failing legalization, and that TcpToLinalg
+// doesn't mark TcpDialect is illegal.
+
+// CHECK-LABEL: func.func @test_constants() -> tensor<f32> {
+// CHECK:         tcp.const {value = dense<2.500000e+00> : tensor<f32>} : tensor<f32>
+func.func @test_constants() -> tensor<f32> {
+  %0 = "tcp.const"() {value = dense<2.5> : tensor<f32>} : () -> tensor<f32>
+  return %0 : tensor<f32>
+}


### PR DESCRIPTION
TcpToLinalg conversion previously marked Tcp dialect as illegal, despite doing a partial conversion. So if there are any leftover Tcp ops after TcpToLinalg, they'd fail legalization (e.g. `tcp.const`). This is not correct and this partial conversion should only mark the Tcp ops it does convert as illegal. This PR fixes that. 