### PR TITLE
More legality fixes in dialect conversions + code consistency cleanup

### DIFF
--- a/lib/Conversion/StablehloToTcp/StablehloToTcp.cpp
+++ b/lib/Conversion/StablehloToTcp/StablehloToTcp.cpp
@@ -40,8 +40,12 @@ public:
   }
 };
 
-void populateStablehloToTcpConversionPatterns(RewritePatternSet *patterns) {
-  patterns->add<TanhOpConverter>(patterns->getContext());
+void populateStablehloToTcpPatternsAndLegality(RewritePatternSet &patterns,
+                                               ConversionTarget &target) {
+  MLIRContext *context = patterns.getContext();
+
+  target.addIllegalOp<stablehlo::TanhOp>();
+  patterns.add<TanhOpConverter>(context);
 }
 
 class ConvertStablehloToTcp
@@ -50,14 +54,10 @@ public:
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ConversionTarget target(*context);
-    target.addIllegalDialect<stablehlo::StablehloDialect>();
     target.addLegalDialect<tcp::TcpDialect>();
 
-    TypeConverter typeConverter;
-    typeConverter.addConversion([](Type type) { return type; });
-
     RewritePatternSet patterns(context);
-    populateStablehloToTcpConversionPatterns(&patterns);
+    populateStablehloToTcpPatternsAndLegality(patterns, target);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))

--- a/lib/Conversion/TcpToArith/TcpToArith.cpp
+++ b/lib/Conversion/TcpToArith/TcpToArith.cpp
@@ -29,11 +29,11 @@ namespace tcp {
 
 namespace {
 
-class ConstOpConverter : public OpRewritePattern<ConstOp> {
+class ConstOpConverter : public OpRewritePattern<tcp::ConstOp> {
 public:
-  using OpRewritePattern<ConstOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(ConstOp op,
+  LogicalResult matchAndRewrite(tcp::ConstOp op,
                                 PatternRewriter &rewriter) const final {
     rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, op.getValue());
     return success();
@@ -44,7 +44,7 @@ void populateTcpToArithPatternsAndLegality(RewritePatternSet &patterns,
                                            ConversionTarget &target) {
   MLIRContext *context = patterns.getContext();
 
-  target.addIllegalOp<ConstOp>();
+  target.addIllegalOp<tcp::ConstOp>();
   patterns.add<ConstOpConverter>(context);
 }
 

--- a/lib/Conversion/TcpToArith/TcpToArith.cpp
+++ b/lib/Conversion/TcpToArith/TcpToArith.cpp
@@ -40,9 +40,11 @@ public:
   }
 };
 
-void populateTcpToArithConversionPatterns(RewritePatternSet &patterns) {
+void populateTcpToArithPatternsAndLegality(RewritePatternSet &patterns,
+                                           ConversionTarget &target) {
   MLIRContext *context = patterns.getContext();
 
+  target.addIllegalOp<ConstOp>();
   patterns.add<ConstOpConverter>(context);
 }
 
@@ -53,11 +55,8 @@ public:
     ConversionTarget target(*context);
     target.addLegalDialect<arith::ArithDialect>();
 
-    TypeConverter typeConverter;
-    typeConverter.addConversion([](Type type) { return type; });
-
     RewritePatternSet patterns(context);
-    populateTcpToArithConversionPatterns(patterns);
+    populateTcpToArithPatternsAndLegality(patterns, target);
 
     if (failed(applyPartialConversion(getOperation(), target,
                                       std::move(patterns))))

--- a/lib/Conversion/TorchToTcp/Elementwise.cpp
+++ b/lib/Conversion/TorchToTcp/Elementwise.cpp
@@ -127,7 +127,7 @@ public:
         return rewriter.notifyMatchFailure(op, "Unsupported alpha data type");
       std::tie(alpha, rhs) =
           torch_to_tcp::broadcastToMatchShape(rewriter, alpha, rhs);
-      rhs = rewriter.create<MulOp>(op->getLoc(), resultType, alpha, rhs);
+      rhs = rewriter.create<tcp::MulOp>(op->getLoc(), resultType, alpha, rhs);
     }
 
     rewriter.replaceOpWithNewOp<TcpOpT>(op, resultType, lhs, rhs);

--- a/lib/Dialect/Transforms/FusionPatterns.cpp
+++ b/lib/Dialect/Transforms/FusionPatterns.cpp
@@ -49,8 +49,8 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
         //   func and the use is already inside a group.
         isChanged = true;
         if (def->getParentRegion() == use->getParentRegion()) {
-          auto groupOp =
-              rewriter.create<GroupOp>(use->getLoc(), use->getResultTypes());
+          auto groupOp = rewriter.create<tcp::GroupOp>(use->getLoc(),
+                                                       use->getResultTypes());
           if (postFunc) {
             postFunc(groupOp, rewriter);
           }
@@ -64,11 +64,11 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
             OpBuilder::InsertionGuard guard(rewriter);
             rewriter.setInsertionPointToStart(groupBlock);
             auto yieldOp =
-                rewriter.create<YieldOp>(use->getLoc(), use->getResults());
+                rewriter.create<tcp::YieldOp>(use->getLoc(), use->getResults());
             use->moveBefore(yieldOp);
             operand.getDefiningOp()->moveBefore(use);
           }
-        } else if (auto groupOp = dyn_cast<GroupOp>(use->getParentOp())) {
+        } else if (auto groupOp = dyn_cast<tcp::GroupOp>(use->getParentOp())) {
           def->moveBefore(use);
         } else {
           llvm_unreachable("Unhandled case during fusion");

--- a/lib/Dialect/Transforms/IsolateGroupOpsPass.cpp
+++ b/lib/Dialect/Transforms/IsolateGroupOpsPass.cpp
@@ -29,11 +29,11 @@ namespace mlir::tcp {
 
 namespace {
 
-class IsolateGroups : public OpRewritePattern<GroupOp> {
+class IsolateGroups : public OpRewritePattern<tcp::GroupOp> {
 public:
-  using OpRewritePattern<GroupOp>::OpRewritePattern;
+  using OpRewritePattern::OpRewritePattern;
 
-  LogicalResult matchAndRewrite(GroupOp groupOp,
+  LogicalResult matchAndRewrite(tcp::GroupOp groupOp,
                                 PatternRewriter &rewriter) const override {
     // Collect the values used in the given GroupOp. Those will be the inputs
     // to the IsolatedGroup op. The constants used in the GroupOp are collected
@@ -57,7 +57,7 @@ public:
       defs.insert(op.getResults().begin(), op.getResults().end());
     }
 
-    auto isolatedGroupOp = rewriter.create<IsolatedGroupOp>(
+    auto isolatedGroupOp = rewriter.create<tcp::IsolatedGroupOp>(
         groupOp.getLoc(), groupOp.getResultTypes(), inputs);
     isolatedGroupOp->setAttrs(groupOp->getAttrs());
 


### PR DESCRIPTION
- [StablehloToTcp] Don't mark entire stablehlo dialect illegal; instead only mark the ops being converted illegal.
- [TcpToArith] Mark `tcp::ConstOp` illegal.
- [NFC] Minor code consistency cleanup