### PR TITLE
[AOT] Support `aten.add.Tensor` with `alpha`, and bufferize arith ops in llvm lowering

### DIFF
--- a/lib/Pipeline/Pipeline.cpp
+++ b/lib/Pipeline/Pipeline.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/Passes.h"
@@ -75,6 +76,7 @@ static void createTcpToLlvmPipeline(OpPassManager &pm) {
       bufferization::createBufferizationBufferizePass());
   pm.addNestedPass<func::FuncOp>(createLinalgBufferizePass());
   pm.addNestedPass<func::FuncOp>(tensor::createTensorBufferizePass());
+  pm.addPass(arith::createConstantBufferizePass());
   pm.addPass(func::createFuncBufferizePass());
   pm.addNestedPass<func::FuncOp>(
       bufferization::createFinalizingBufferizePass());

--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -37,6 +37,12 @@ aot_compile(
 )
 
 aot_compile(
+    name = "add_tensor_with_alpha",
+    torch_loader_lib = ":model_loader_lib",
+    torch_loader_path = "test.AotCompile.model_loader_lib.add_tensor_with_alpha_loader",
+)
+
+aot_compile(
     name = "sigmoid",
     torch_loader_lib = ":model_loader_lib",
     torch_loader_path = "test.AotCompile.model_loader_lib.sigmoid_loader",

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -10,7 +10,7 @@ from tools.aot.torch_loader_utils import TorchLoaderOutput
 
 
 def add_mul_single_output_loader() -> TorchLoaderOutput:
-    class AddMulNetSingleOutput(torch.nn.Module):
+    class AddMulSingleOutput(torch.nn.Module):
         def __init__(self):
             super().__init__()
 
@@ -36,14 +36,14 @@ def add_mul_single_output_loader() -> TorchLoaderOutput:
     }
 
     return TorchLoaderOutput(
-        model=AddMulNetSingleOutput(),
+        model=AddMulSingleOutput(),
         inputs=(x, y, z),
         dynamic_shapes=dynamic_shapes,
     )
 
 
 def add_mul_multi_output_loader() -> TorchLoaderOutput:
-    class AddMulNetMultiOutput(torch.nn.Module):
+    class AddMulMultiOutput(torch.nn.Module):
         def __init__(self):
             super().__init__()
 
@@ -69,7 +69,7 @@ def add_mul_multi_output_loader() -> TorchLoaderOutput:
     }
 
     return TorchLoaderOutput(
-        model=AddMulNetMultiOutput(),
+        model=AddMulMultiOutput(),
         inputs=(x, y, z),
         dynamic_shapes=dynamic_shapes,
     )
@@ -116,14 +116,16 @@ def add_tensor_with_alpha_loader() -> TorchLoaderOutput:
     y = torch.randn(2, 3)
 
     # Dynamic dim constraints
-    constraints = [
-        dynamic_dim(x, 0) == dynamic_dim(y, 0),
-    ]
+    batch = Dim("batch")
+    dynamic_shapes = {
+        "x": {0: batch},
+        "y": {0: batch},
+    }
 
     return TorchLoaderOutput(
         model=AddTensorWithAlpha(),
-        inputs=[x, y],
-        constraints=constraints,
+        inputs=(x, y),
+        dynamic_shapes=dynamic_shapes,
     )
 
 

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -102,6 +102,31 @@ def broadcast_add_mixed_ranks_loader() -> TorchLoaderOutput:
     )
 
 
+def add_tensor_with_alpha_loader() -> TorchLoaderOutput:
+    class AddTensorWithAlpha(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            add = torch.add(x, y, alpha=2)
+            return add
+
+    # Sample inputs
+    x = torch.randn(2, 3)
+    y = torch.randn(2, 3)
+
+    # Dynamic dim constraints
+    constraints = [
+        dynamic_dim(x, 0) == dynamic_dim(y, 0),
+    ]
+
+    return TorchLoaderOutput(
+        model=AddTensorWithAlpha(),
+        inputs=[x, y],
+        constraints=constraints,
+    )
+
+
 def sigmoid_loader() -> TorchLoaderOutput:
     class Sigmoid(torch.nn.Module):
         def __init__(self):


### PR DESCRIPTION
This required two fixes to get working:
1. FIx legality conditions in TcpToLinalg (https://github.com/cruise-automation/mlir-tcp/pull/54)
2. Add arith-bufferize pass in our pipeline (this PR)

Torch dialect program:
```ll
module {                                                                                                                                                                                                                                                                
  func.func @func_main(%arg0: !torch.vtensor<[?,3],f32>, %arg1: !torch.vtensor<[?,3],f32>) -> !torch.vtensor<[?,3],f32> {                                                                                                                                               
    %int2 = torch.constant.int 2                                                                                                                                                                                                                                        
    %0 = torch.aten.add.Tensor %arg0, %arg1, %int2 : !torch.vtensor<[?,3],f32>, !torch.vtensor<[?,3],f32>, !torch.int -> !torch.vtensor<[?,3],f32>                                                                                                                      
    return %0 : !torch.vtensor<[?,3],f32>                                                                                                                                                                                                                               
  }                                                                                                                                                                                                                                                                     
} 
```

TCP dialect program:
```ll
module {                                                                                                                                                                                                                                                                
  func.func @func_main(%arg0: tensor<?x3xf32>, %arg1: tensor<?x3xf32>) -> tensor<?x3xf32> {                                                                                                                                                                             
    %0 = tcp.const {value = dense<2> : tensor<i64>} : tensor<i64>                                                                                                                                                                                                       
    %c0 = arith.constant 0 : index                                                                                                                                                                                                                                      
    %c3 = arith.constant 3 : index                                                                                                                                                                                                                                      
    %1 = tcp.cast %0 {in_int_signedness = #tcp<signedness Signed>} : tensor<i64> -> tensor<f32>                                                                                                                                                                         
    %expanded = tensor.expand_shape %1 [] : tensor<f32> into tensor<1x1xf32>                                                                                                                                                                                            
    %dim = tensor.dim %arg1, %c0 : tensor<?x3xf32>                                                                                                                                                                                                                      
    %2 = tcp.broadcast %expanded, %dim, %c3 {axes = [0, 1]} : tensor<1x1xf32>, index, index -> tensor<?x3xf32>                                                                                                                                                          
    %3 = tcp.mul %2, %arg1 : tensor<?x3xf32>, tensor<?x3xf32> -> tensor<?x3xf32>                                                                                                                                                                                        
    %4 = tcp.add %arg0, %3 : tensor<?x3xf32>, tensor<?x3xf32> -> tensor<?x3xf32>                                                                                                                                                                                        
    return %4 : tensor<?x3xf32>                                                                                                                                                                                                                                         
  }                                                                                                                                                                                                                                                                     
}
```