### PR TITLE
Adopt new dynamic_shapes API from torch.export

### DIFF
--- a/requirements_lock.txt
+++ b/requirements_lock.txt
@@ -130,23 +130,23 @@ numpy==1.26.4 \
     # via
     #   -r requirements.txt
     #   torch-mlir
-packaging==23.2 \
-    --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
-    --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
+packaging==24.0 \
+    --hash=sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5 \
+    --hash=sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9
     # via torch-mlir
 sympy==1.12 \
     --hash=sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5 \
     --hash=sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8
     # via torch
-torch==2.3.0.dev20240220+cpu \
-    --hash=sha256:03ca173f8cbf3e75035f7648ab93adbc8d90dea28d2b32aada53b7d64bc81a95 \
-    --hash=sha256:d55f8221662c555243af1dc7c9ba861ddb3c69d037fd64677b29b662bb8d2a18
+torch==2.3.0.dev20240307+cpu \
+    --hash=sha256:a2f80665c1a677f30f285ee3470425e3880fbcf32f440f1ed243677bcd9e726c \
+    --hash=sha256:e4287a72966b9d9922372aae4ee8d2ef26121590b908ba1f604139c1079eb0ee
     # via
     #   -r requirements.txt
     #   torch-mlir
-torch-mlir==20240306.29 \
-    --hash=sha256:c505cb254196f694ba1447af0ba3300d514fafe5520c2b3266d5d9c2e9ee4f93 \
-    --hash=sha256:da91a833acfba6e80def65295a805156af1399447a141c46f1becdf5f7ae13a3
+torch-mlir==20240314.38 \
+    --hash=sha256:e8eba263428ab0a53d06a2653e880a0641990a24106a97a42fe736b669aeb9f4 \
+    --hash=sha256:fbc614ad2186766e6060b086d6744608f7d7066b9f9d35bf2fc4bfa4e5d270c8
     # via -r requirements.txt
 typing-extensions==4.10.0 \
     --hash=sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475 \

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -4,7 +4,7 @@
 # Also available under a BSD-style license. See LICENSE.
 
 import torch
-from torch.export import dynamic_dim
+from torch.export import Dim
 
 from tools.aot.torch_loader_utils import TorchLoaderOutput
 
@@ -27,19 +27,18 @@ def add_mul_single_output_loader() -> TorchLoaderOutput:
     z = torch.randn(2, 3)
 
     # Dynamic dim constraints
-    constraints = [
-        # Dim 1
-        dynamic_dim(x, 0) == dynamic_dim(y, 0),
-        dynamic_dim(y, 0) == dynamic_dim(z, 0),
-        # Dim 2
-        dynamic_dim(x, 1) == dynamic_dim(y, 1),
-        dynamic_dim(y, 1) == dynamic_dim(z, 1),
-    ]
+    dim_0 = Dim("dim_0")
+    dim_1 = Dim("dim_1")
+    dynamic_shapes = {
+        "x": {0: dim_0, 1: dim_1},
+        "y": {0: dim_0, 1: dim_1},
+        "z": {0: dim_0, 1: dim_1},
+    }
 
     return TorchLoaderOutput(
         model=AddMulNetSingleOutput(),
-        inputs=[x, y, z],
-        constraints=constraints,
+        inputs=(x, y, z),
+        dynamic_shapes=dynamic_shapes,
     )
 
 
@@ -61,19 +60,18 @@ def add_mul_multi_output_loader() -> TorchLoaderOutput:
     z = torch.randn(2, 3)
 
     # Dynamic dim constraints
-    constraints = [
-        # Dim 1
-        dynamic_dim(x, 0) == dynamic_dim(y, 0),
-        dynamic_dim(y, 0) == dynamic_dim(z, 0),
-        # Dim 2
-        dynamic_dim(x, 1) == dynamic_dim(y, 1),
-        dynamic_dim(y, 1) == dynamic_dim(z, 1),
-    ]
+    dim_0 = Dim("dim_0")
+    dim_1 = Dim("dim_1")
+    dynamic_shapes = {
+        "x": {0: dim_0, 1: dim_1},
+        "y": {0: dim_0, 1: dim_1},
+        "z": {0: dim_0, 1: dim_1},
+    }
 
     return TorchLoaderOutput(
         model=AddMulNetMultiOutput(),
-        inputs=[x, y, z],
-        constraints=constraints,
+        inputs=(x, y, z),
+        dynamic_shapes=dynamic_shapes,
     )
 
 
@@ -91,12 +89,16 @@ def broadcast_add_mixed_ranks_loader() -> TorchLoaderOutput:
     y = torch.randn(2)
 
     # Dynamic dim constraints
-    constraints = [dynamic_dim(y, 0)]
+    batch = Dim("batch")
+    dynamic_shapes = {
+        "x": None,
+        "y": {0: batch},
+    }
 
     return TorchLoaderOutput(
         model=BroadcastAddMixedRanks(),
-        inputs=[x, y],
-        constraints=constraints,
+        inputs=(x, y),
+        dynamic_shapes=dynamic_shapes,
     )
 
 
@@ -112,15 +114,16 @@ def sigmoid_loader() -> TorchLoaderOutput:
     x = torch.randn(2, 3)
 
     # Dynamic dim constraints
-    constraints = [
-        dynamic_dim(x, 0),
-        dynamic_dim(x, 1),
-    ]
+    dim_0 = Dim("dim_0")
+    dim_1 = Dim("dim_1")
+    dynamic_shapes = {
+        "x": {0: dim_0, 1: dim_1},
+    }
 
     return TorchLoaderOutput(
         model=Sigmoid(),
-        inputs=[x],
-        constraints=constraints,
+        inputs=(x,),
+        dynamic_shapes=dynamic_shapes,
     )
 
 
@@ -137,15 +140,17 @@ def concat_float_tensors_loader() -> TorchLoaderOutput:
     y = torch.randn(3, 3)
 
     # Dynamic dim constraints
-    constraints = [
-        dynamic_dim(x, 0),
-        dynamic_dim(y, 0),
-    ]
+    batch_x = Dim("batch_x")
+    batch_y = Dim("batch_y")
+    dynamic_shapes = {
+        "x": {0: batch_x},
+        "y": {0: batch_y},
+    }
 
     return TorchLoaderOutput(
         model=ConcatFloatTensors(),
-        inputs=[x, y],
-        constraints=constraints,
+        inputs=(x, y),
+        dynamic_shapes=dynamic_shapes,
     )
 
 
@@ -162,15 +167,17 @@ def concat_int_tensors_loader() -> TorchLoaderOutput:
     y = torch.randint(2, 8, (3, 3), dtype=torch.int32)
 
     # Dynamic dim constraints
-    constraints = [
-        dynamic_dim(x, 0),
-        dynamic_dim(y, 0),
-    ]
+    batch_x = Dim("batch_x")
+    batch_y = Dim("batch_y")
+    dynamic_shapes = {
+        "x": {0: batch_x},
+        "y": {0: batch_y},
+    }
 
     return TorchLoaderOutput(
         model=ConcatIntTensors(),
-        inputs=[x, y],
-        constraints=constraints,
+        inputs=(x, y),
+        dynamic_shapes=dynamic_shapes,
     )
 
 
@@ -186,12 +193,13 @@ def slice_tensor_loader() -> TorchLoaderOutput:
     x = torch.randn(4, 3)
 
     # Dynamic dim constraints
-    constraints = [
-        dynamic_dim(x, 0) > 2,
-    ]
+    batch = Dim("batch", min=3)
+    dynamic_shapes = {
+        "x": {0: batch},
+    }
 
     return TorchLoaderOutput(
         model=SliceTensor(),
-        inputs=[x],
-        constraints=constraints,
+        inputs=(x,),
+        dynamic_shapes=dynamic_shapes,
     )

--- a/tools/aot/torch_exporter_harness.py
+++ b/tools/aot/torch_exporter_harness.py
@@ -37,8 +37,8 @@ def main():
         loader_result, TorchLoaderOutput
     ), "Please use tools.aot.torch_loader_utils.TorchLoaderOutput as your torch_loader function's return type"
     assert isinstance(
-        loader_result.inputs, list
-    ), "Please provide List[torch.Tensor] as TorchLoaderOutput.inputs in your torch_loader function"
+        loader_result.inputs, tuple
+    ), "Please provide Tuple[torch.Tensor] as TorchLoaderOutput.inputs in your torch_loader function"
 
     # Used by gen_{name}_mlir_torch genrule
     if not args.reference_tensors_path:
@@ -46,7 +46,7 @@ def main():
         torch_program = fx.export_and_import(
             loader_result.model,
             *loader_result.inputs,  # unpack list of input tensors
-            constraints=loader_result.constraints,
+            dynamic_shapes=loader_result.dynamic_shapes,
             func_name=loader_result.func_name,
         )
 

--- a/tools/aot/torch_loader_utils.py
+++ b/tools/aot/torch_loader_utils.py
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # Also available under a BSD-style license. See LICENSE.
 
-from typing import List, NamedTuple, Optional
+from typing import NamedTuple, Optional, Tuple, Union, Dict, Any
 
 import torch
 
 
 class TorchLoaderOutput(NamedTuple):
     model: torch.nn.Module
-    inputs: List[torch.Tensor]
-    constraints: Optional[List[torch.export.dynamic_dim]] = None
+    inputs: Tuple[torch.Tensor]
+    dynamic_shapes: Optional[Union[Dict[str, Any], Tuple[Any]]] = None
     func_name: Optional[str] = "func_main"


### PR DESCRIPTION
`constraints` was soft-deprecated for a while now, superseded by `dynamic_shapes` but https://github.com/pytorch/pytorch/pull/120860 hard-deprecates it. This PR adopts the new API and pulls in torch-mlir fixes: https://github.com/llvm/torch-mlir/pull/3026. 