### PR TITLE
[TorchToTcp] Don't broadcast axes that don't change size

### DIFF
--- a/lib/Conversion/TorchToTcp/Misc.cpp
+++ b/lib/Conversion/TorchToTcp/Misc.cpp
@@ -68,6 +68,8 @@ public:
     Value input = adaptor.getSelf();
     RankedTensorType inputType = input.getType().dyn_cast<RankedTensorType>();
 
+    ArrayRef<int64_t> inputShape = inputType.getShape();
+
     SmallVector<Value> newDimSizes;
     if (!getListConstructElements(op.getSize(), newDimSizes))
       return rewriter.notifyMatchFailure(
@@ -86,7 +88,8 @@ public:
       int64_t staticDimSize;
       if (i < newLeadingDims ||
           !matchPattern(newDimSize, m_TorchConstantInt(&staticDimSize)) ||
-          staticDimSize != -1) {
+          (staticDimSize != -1 &&
+           staticDimSize != inputShape[i - newLeadingDims])) {
         axes.push_back(i);
         newDimSize = rewriter.create<torch::TorchConversion::ToI64Op>(
             op->getLoc(), newDimSize);

--- a/lib/Conversion/TorchToTcp/Misc.cpp
+++ b/lib/Conversion/TorchToTcp/Misc.cpp
@@ -76,38 +76,44 @@ public:
           op, "Broadcasted shape must be a list of scalars");
 
     int64_t newLeadingDims = newDimSizes.size() - inputType.getRank();
-    if (newLeadingDims > 0) {
+    if (newLeadingDims > 0)
       input = torch_to_tcp::broadcastRankInLeadingDims(rewriter, input,
                                                        newLeadingDims);
-    }
 
     SmallVector<int64_t> axes;
     SmallVector<Value> resultShape;
     for (int64_t i = 0; i < static_cast<int64_t>(newDimSizes.size()); ++i) {
       Value newDimSize = newDimSizes[i];
 
+      // Per PyTorch, "Tensor can be also expanded to a larger number of
+      // dimensions, and the new ones will be appended at the front. For
+      // the new dimensions, the size cannot be set to -1.", so this dim is
+      // always broadcasted (no need to check for `isDimSizePreserved` below)
       bool isNewDim = i < newLeadingDims;
-      // At the pytorch level it's possible to broadcast to a dynamic dimension;
+      // PyTorch semantics allow for a broadcast to a dynamic dimension;
       // for example: `torch.broadcast_to(x, y.size())` where `y.size()` has
-      // dynamic shapes. When broadcasting to dynamic size, matchPattern fails
-      // to read an int out of the MLIR Value. In the "usual" case
+      // dynamic shapes. When broadcasting to dynamic size, matchPattern for
+      // `torch.constant.int` fails, and we do not read `staticDimSize` (an int)
+      // out of `newDimSize` (an mlir::Value). In the "static" case
       // (`torch.broadcast_to(x, (3, 3))`) matchPattern will succeed.
       int64_t staticDimSize;
-      bool isDimDynamic =
+      bool isDynamicDim =
           !matchPattern(newDimSize, m_TorchConstantInt(&staticDimSize));
-      // pytorch defines "passing -1 as the size for a dimension means not
-      // changing the size of that dimension." Short circuit if dim is dynamic
-      // as staticDimSize won't have a valid value.
-      bool isDimSizePreserved = isDimDynamic ? false : staticDimSize == -1;
-      // Short circuit if isNewDim to prevent out of bounds access of
-      // inputShape.
-      bool doesDimChangeShape =
-          isDimDynamic || isNewDim
-              ? false
+      // Per PyTorch, "passing -1 as the size for a dimension means not
+      // changing the size of that dimension". Don't evaluate if `isDynamicDim`
+      // (as `staticDimSize` won't have a valid value).
+      bool isDimSizePreserved = isDynamicDim ? false : staticDimSize == -1;
+      // Don't evaluate if `isNewDim` (to prevent out of bounds access on
+      // `inputShape`) or if `isDynamicDim` (as `staticDimSize` won't have
+      // a valid value).
+      bool doesDimSizeChange =
+          (isDynamicDim || isNewDim)
+              ? true
               : staticDimSize != inputShape[i - newLeadingDims];
 
-      if (isNewDim || isDimDynamic ||
-          (!isDimSizePreserved && doesDimChangeShape)) {
+      // Note: The order of checks in this boolean expression matters!
+      if (isNewDim || isDynamicDim ||
+          (!isDimSizePreserved && doesDimSizeChange)) {
         axes.push_back(i);
         newDimSize = rewriter.create<torch::TorchConversion::ToI64Op>(
             op->getLoc(), newDimSize);

--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -18,8 +18,7 @@ AOT_TEST_SUITE = [
     ("concat_float_tensors", False),
     ("concat_int_tensors", False),
     ("slice_tensor", False),
-    # FIXME: don't broadcast dims that are the same
-    ("broadcast_unit_dim_to_static_with_explicit_dim_static", True),
+    ("broadcast_unit_dim_to_static_with_explicit_dim_static", False),
     ("broadcast_unit_dim_to_static_with_unchanged_dim_static", False),
     ("broadcast_unit_dim_to_static_with_unchanged_dim_dynamic", False),
     ("broadcast_unit_dim_to_dynamic_with_unchanged_dim_static", False),

--- a/test/Conversion/TorchToTcp/misc.mlir
+++ b/test/Conversion/TorchToTcp/misc.mlir
@@ -340,4 +340,22 @@ func.func @torch.aten.expand(%arg0: !torch.vtensor<[1,2],f32>) -> !torch.vtensor
   %false = torch.constant.bool false
   %1 = torch.aten.expand %arg0, %0, %false : !torch.vtensor<[1,2],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,2],f32>
   return %1 : !torch.vtensor<[3,2],f32>
+
+// -----
+
+// CHECK-LABEL:  @torch.aten.broadcast_to(
+// CHECK-SAME:   %[[ARG:.*]]: !torch.vtensor<[1,2,1,2],f32>) {
+// CHECK:        %[[TENSOR:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[1,2,1,2],f32> -> tensor<1x2x1x2xf32>
+// CHECK:        %[[CONSTANT:.*]] = torch.constant.int 4
+// CHECK:        %[[CAST0:.*]] = torch_c.to_i64 %[[CONSTANT]]
+// CHECK:        %[[BROADCAST_DIM0:.*]] = arith.index_cast %[[CAST0]] : i64 to index
+// CHECK:        %[[CAST1:.*]] = torch_c.to_i64 %[[CONSTANT]]
+// CHECK:        %[[BROADCAST_DIM1:.*]] = arith.index_cast %[[CAST1]] : i64 to index
+// CHECK:        %{{.*}} = tcp.broadcast %[[TENSOR]], %[[BROADCAST_DIM0]], %[[BROADCAST_DIM1]] {axes = [0, 2]} : tensor<1x2x1x2xf32>, index, index -> tensor<4x2x4x2xf32>
+func.func @torch.aten.broadcast_to(%arg0: !torch.vtensor<[1,2,1,2],f32>) -> () {
+  %int2 = torch.constant.int 2
+  %int4 = torch.constant.int 4
+  %1 = torch.prim.ListConstruct %int4, %int2, %int4, %int2 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
+  %2 = torch.aten.broadcast_to %arg0, %1 : !torch.vtensor<[1,2,1,2],f32>, !torch.list<int> -> !torch.vtensor<[4,2,4,2],f32>
+  return
 }

--- a/test/Conversion/TorchToTcp/misc.mlir
+++ b/test/Conversion/TorchToTcp/misc.mlir
@@ -340,24 +340,27 @@ func.func @torch.aten.expand(%arg0: !torch.vtensor<[1,2],f32>) -> !torch.vtensor
   %false = torch.constant.bool false
   %1 = torch.aten.expand %arg0, %0, %false : !torch.vtensor<[1,2],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,2],f32>
   return %1 : !torch.vtensor<[3,2],f32>
+}
 
 // -----
 
 // CHECK-LABEL:  @torch.aten.broadcast_to(
-// CHECK-SAME:   %[[ARG:.*]]: !torch.vtensor<[1,2,1,2],f32>) {
+// CHECK-SAME:   %[[ARG:.*]]: !torch.vtensor<[1,2,1,2],f32>) -> !torch.vtensor<[4,2,4,2],f32> {
 // CHECK:        %[[TENSOR:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[1,2,1,2],f32> -> tensor<1x2x1x2xf32>
 // CHECK:        %[[CONSTANT:.*]] = torch.constant.int 4
 // CHECK:        %[[CAST0:.*]] = torch_c.to_i64 %[[CONSTANT]]
 // CHECK:        %[[BROADCAST_DIM0:.*]] = arith.index_cast %[[CAST0]] : i64 to index
 // CHECK:        %[[CAST1:.*]] = torch_c.to_i64 %[[CONSTANT]]
 // CHECK:        %[[BROADCAST_DIM1:.*]] = arith.index_cast %[[CAST1]] : i64 to index
-// CHECK:        %{{.*}} = tcp.broadcast %[[TENSOR]], %[[BROADCAST_DIM0]], %[[BROADCAST_DIM1]] {axes = [0, 2]} : tensor<1x2x1x2xf32>, index, index -> tensor<4x2x4x2xf32>
-func.func @torch.aten.broadcast_to(%arg0: !torch.vtensor<[1,2,1,2],f32>) -> () {
+// CHECK:        %[[AFTER_BROADCAST:.*]] = tcp.broadcast %[[TENSOR]], %[[BROADCAST_DIM0]], %[[BROADCAST_DIM1]] {axes = [0, 2]} : tensor<1x2x1x2xf32>, index, index -> tensor<4x2x4x2xf32>
+// CHECK:        %[[OUT:.*]] = torch_c.from_builtin_tensor %[[AFTER_BROADCAST]] : tensor<4x2x4x2xf32> -> !torch.vtensor<[4,2,4,2],f32>
+// CHECK:        return %[[OUT]] : !torch.vtensor<[4,2,4,2],f32>
+func.func @torch.aten.broadcast_to(%arg0: !torch.vtensor<[1,2,1,2],f32>) -> !torch.vtensor<[4,2,4,2],f32> {
   %int2 = torch.constant.int 2
   %int4 = torch.constant.int 4
   %1 = torch.prim.ListConstruct %int4, %int2, %int4, %int2 : (!torch.int, !torch.int, !torch.int, !torch.int) -> !torch.list<int>
   %2 = torch.aten.broadcast_to %arg0, %1 : !torch.vtensor<[1,2,1,2],f32>, !torch.list<int> -> !torch.vtensor<[4,2,4,2],f32>
-  return
+  return %2 : !torch.vtensor<[4,2,4,2],f32>
 }
 
 // -----

--- a/test/Dialect/misc.mlir
+++ b/test/Dialect/misc.mlir
@@ -65,6 +65,22 @@ func.func @test_broadcast_axes_w_duplicates(%arg0 : tensor<?x1x?x1xf32>, %arg1 :
 
 // -----
 
+func.func @test_broadcast_axes_out_of_bounds(%arg0 : tensor<?x1x?x1xf32>, %arg1 : index, %arg2 : index) -> tensor<?x?x?x?xf32> {
+  // expected-error@+1{{'tcp.broadcast' op failed to verify that attribute `axes` are in bounds}}
+  %0 = tcp.broadcast %arg0, %arg1, %arg2 {axes = [1, 100]} : tensor<?x1x?x1xf32>, index, index -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
+func.func @test_broadcast_axes_not_1(%arg0 : tensor<?x7x?x1xf32>, %arg1 : index, %arg2 : index) -> tensor<?x?x?x?xf32> {
+  // expected-error@+1{{'tcp.broadcast' op failed to verify that dimensions listed in attribute `axes` have a static size of `1`}}
+  %0 = tcp.broadcast %arg0, %arg1, %arg2 {axes = [1, 1]} : tensor<?x7x?x1xf32>, index, index -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_group(
 // CHECK-SAME:          %[[ARG0:.*]]: tensor<?x?xf32>,
 // CHECK-SAME:          %[[ARG1:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>

--- a/test/Dialect/misc.mlir
+++ b/test/Dialect/misc.mlir
@@ -75,7 +75,7 @@ func.func @test_broadcast_axes_out_of_bounds(%arg0 : tensor<?x1x?x1xf32>, %arg1 
 
 func.func @test_broadcast_axes_not_1(%arg0 : tensor<?x7x?x1xf32>, %arg1 : index, %arg2 : index) -> tensor<?x?x?x?xf32> {
   // expected-error@+1{{'tcp.broadcast' op failed to verify that dimensions listed in attribute `axes` have a static size of `1`}}
-  %0 = tcp.broadcast %arg0, %arg1, %arg2 {axes = [1, 1]} : tensor<?x7x?x1xf32>, index, index -> tensor<?x?x?x?xf32>
+  %0 = tcp.broadcast %arg0, %arg1, %arg2 {axes = [1, 3]} : tensor<?x7x?x1xf32>, index, index -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
 }
 


### PR DESCRIPTION
Ran into this a bug in Cruse internal repo, the changes here fix the issue. Here's an example of incorrect lowering:
```mlir
  %4 = torch.aten.broadcast_to %3, %1 : !torch.vtensor<[1,2,1,2],f32>, !torch.list<int> -> !torch.vtensor<[4,2,4,2],f32>
```
was lowering to 
```mlir
%13 = tcp.broadcast %4, %6, %8, %10, %12 {axes = [0, 1, 2, 3]} : tensor<1x2x1x2xf32>, index, index, index, index -> tensor<4x2x4x2xf32>
```
axes 1 and 3 should not be broadcasted as those axes stay the same shape. The correct lowering is
```mlir
%13 = tcp.broadcast %4, %6, %10 {axes = [0, 2]} : tensor<1x2x1x2xf32>, index, index -> tensor<4x2x4x2xf32>
```