### PR TITLE
[TorchToTcp] [AOT] Lower `aten.expand` op to `tcp.broadcast` 

### DIFF
--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -18,8 +18,10 @@ AOT_TEST_SUITE = [
     ("concat_float_tensors", False),
     ("concat_int_tensors", False),
     ("slice_tensor", False),
-    # FIXME: broadcast broken
-    ("broadcast_to", True),
+    # FIXME: don't broadcast dims that are the same
+    ("broadcast_unit_dim_to_static_with_explicit_dim_static", True),
+    ("broadcast_unit_dim_to_static_with_unchanged_dim_static", False),
+    ("broadcast_unit_dim_to_static_with_unchanged_dim_dynamic", False),
 ]
 
 py_library(

--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -22,6 +22,8 @@ AOT_TEST_SUITE = [
     ("broadcast_unit_dim_to_static_with_explicit_dim_static", True),
     ("broadcast_unit_dim_to_static_with_unchanged_dim_static", False),
     ("broadcast_unit_dim_to_static_with_unchanged_dim_dynamic", False),
+    ("broadcast_unit_dim_to_dynamic_with_unchanged_dim_static", False),
+    ("broadcast_unit_dim_to_dynamic_with_unchanged_dim_dynamic", False),
 ]
 
 py_library(

--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -35,9 +35,9 @@ py_library(
 [
     aot_compile(
         name = test_name,
+        skip_ci = skip_ci,
         torch_loader_lib = ":model_loader_lib",
         torch_loader_path = "test.AotCompile.model_loader_lib.%s_loader" % test_name,
-        skip_ci = skip_ci,
     )
     for test_name, skip_ci in AOT_TEST_SUITE
 ]

--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -9,14 +9,17 @@ load("@rules_python//python:defs.bzl", "py_library")
 load("@pip_deps//:requirements.bzl", "requirement")
 
 AOT_TEST_SUITE = [
-    "add_mul_single_output",
-    "add_mul_multi_output",
-    "broadcast_add_mixed_ranks",
-    "add_tensor_with_alpha",
-    "sigmoid",
-    "concat_float_tensors",
-    "concat_int_tensors",
-    "slice_tensor",
+    # (test_name, skip_ci)
+    ("add_mul_single_output", False),
+    ("add_mul_multi_output", False),
+    ("broadcast_add_mixed_ranks", False),
+    ("add_tensor_with_alpha", False),
+    ("sigmoid", False),
+    ("concat_float_tensors", False),
+    ("concat_int_tensors", False),
+    ("slice_tensor", False),
+    # FIXME: broadcast broken
+    ("broadcast_to", True),
 ]
 
 py_library(
@@ -31,11 +34,12 @@ py_library(
 
 [
     aot_compile(
-        name = test,
+        name = test_name,
         torch_loader_lib = ":model_loader_lib",
-        torch_loader_path = "test.AotCompile.model_loader_lib.%s_loader" % test,
+        torch_loader_path = "test.AotCompile.model_loader_lib.%s_loader" % test_name,
+        skip_ci = skip_ci,
     )
-    for test in AOT_TEST_SUITE
+    for test_name, skip_ci in AOT_TEST_SUITE
 ]
 
 aot_compile(

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -232,8 +232,8 @@ def slice_tensor_loader() -> TorchLoaderOutput:
     )
 
 
-def broadcast_to_loader() -> TorchLoaderOutput:
-    class BroadcastTo(torch.nn.Module):
+def broadcast_unit_dim_to_static_with_explicit_dim_static_loader() -> TorchLoaderOutput:
+    class BroadcastUnitDimToStaticWithExplicitDimStatic(torch.nn.Module):
         def __init__(self):
             super().__init__()
 
@@ -244,6 +244,50 @@ def broadcast_to_loader() -> TorchLoaderOutput:
     x = torch.randn(1, 2)
 
     return TorchLoaderOutput(
-        model=BroadcastTo(),
+        model=BroadcastUnitDimToStaticWithExplicitDimStatic(),
         inputs=(x,),
+    )
+
+
+def broadcast_unit_dim_to_static_with_unchanged_dim_static_loader() -> (
+    TorchLoaderOutput
+):
+    class BroadcastUnitDimToStaticWithUnchangedDimStatic(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.broadcast_to(x, (3, -1))
+
+    # Sample inputs
+    x = torch.randn(1, 2)
+
+    return TorchLoaderOutput(
+        model=BroadcastUnitDimToStaticWithUnchangedDimStatic(),
+        inputs=(x,),
+    )
+
+
+def broadcast_unit_dim_to_static_with_unchanged_dim_dynamic_loader() -> (
+    TorchLoaderOutput
+):
+    class BroadcastUnitDimToStaticWithUnchangedDimDynamic(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.broadcast_to(x, (3, -1))
+
+    # Sample inputs
+    x = torch.randn(1, 2)
+
+    dim_1 = Dim("batch")
+    dynamic_shapes = {
+        "x": {1: dim_1},
+    }
+
+    return TorchLoaderOutput(
+        model=BroadcastUnitDimToStaticWithUnchangedDimDynamic(),
+        inputs=(x,),
+        dynamic_shapes=dynamic_shapes,
     )

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -230,3 +230,20 @@ def slice_tensor_loader() -> TorchLoaderOutput:
         inputs=(x,),
         dynamic_shapes=dynamic_shapes,
     )
+
+
+def broadcast_to_loader() -> TorchLoaderOutput:
+    class BroadcastTo(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.broadcast_to(x, (3, 2))
+
+    # Sample inputs
+    x = torch.randn(1, 2)
+
+    return TorchLoaderOutput(
+        model=BroadcastTo(),
+        inputs=(x,),
+    )

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -281,7 +281,7 @@ def broadcast_unit_dim_to_static_with_unchanged_dim_dynamic_loader() -> (
     # Sample inputs
     x = torch.randn(1, 2)
 
-    dim_1 = Dim("batch")
+    dim_1 = Dim("dim_1")
     dynamic_shapes = {
         "x": {1: dim_1},
     }
@@ -289,5 +289,60 @@ def broadcast_unit_dim_to_static_with_unchanged_dim_dynamic_loader() -> (
     return TorchLoaderOutput(
         model=BroadcastUnitDimToStaticWithUnchangedDimDynamic(),
         inputs=(x,),
+        dynamic_shapes=dynamic_shapes,
+    )
+
+
+def broadcast_unit_dim_to_dynamic_with_unchanged_dim_static_loader() -> (
+    TorchLoaderOutput
+):
+    class BroadcastUnitDimToDynamicWithUnchangedDimStatic(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.broadcast_to(x, (y.shape[0], -1))
+
+    # Sample inputs
+    x = torch.randn(1, 2)
+    y = torch.randn(10)
+
+    dim_0 = Dim("dim_0")
+    dynamic_shapes = {
+        "x": {},
+        "y": {0: dim_0},
+    }
+
+    return TorchLoaderOutput(
+        model=BroadcastUnitDimToDynamicWithUnchangedDimStatic(),
+        inputs=(x, y),
+        dynamic_shapes=dynamic_shapes,
+    )
+
+
+def broadcast_unit_dim_to_dynamic_with_unchanged_dim_dynamic_loader() -> (
+    TorchLoaderOutput
+):
+    class BroadcastUnitDimToDynamicWithUnchangedDimDynamic(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+            return torch.broadcast_to(x, (y.shape[0], -1))
+
+    # Sample inputs
+    x = torch.randn(1, 2)
+    y = torch.randn(10)
+
+    dim_0 = Dim("dim_0")
+    dim_1 = Dim("dim_1")
+    dynamic_shapes = {
+        "x": {1: dim_1},
+        "y": {0: dim_0},
+    }
+
+    return TorchLoaderOutput(
+        model=BroadcastUnitDimToDynamicWithUnchangedDimDynamic(),
+        inputs=(x, y),
         dynamic_shapes=dynamic_shapes,
     )

--- a/test/Conversion/TorchToTcp/misc.mlir
+++ b/test/Conversion/TorchToTcp/misc.mlir
@@ -325,3 +325,21 @@ func.func @torch.aten.size.int(%arg0: !torch.vtensor<[?,?],f32>) -> () {
 
 // -----
 
+// CHECK-LABEL:  @torch.aten.expand(
+// CHECK-SAME:   %[[ARG:.*]]: !torch.vtensor<[1,2],f32>) -> !torch.vtensor<[3,2],f32> {
+// CHECK:        %[[TENSOR:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[1,2],f32> -> tensor<1x2xf32>
+// CHECK:        %[[CONSTANT3:.*]] = torch.constant.int 3
+// CHECK:        %[[CONSTANT2:.*]] = torch.constant.int 2
+// CHECK:        %[[CAST0:.*]] = torch_c.to_i64 %[[CONSTANT3]]
+// CHECK:        %[[BROADCAST_DIM0:.*]] = arith.index_cast %[[CAST0]] : i64 to index
+// CHECK:        %[[CAST1:.*]] = torch_c.to_i64 %[[CONSTANT2]]
+// CHECK:        %[[BROADCAST_DIM1:.*]] = arith.index_cast %[[CAST1]] : i64 to index
+// CHECK:        %{{.*}} = tcp.broadcast %[[TENSOR]], %[[BROADCAST_DIM0]], %[[BROADCAST_DIM1]] {axes = [0, 1]} : tensor<1x2xf32>, index, index -> tensor<3x2xf32>
+func.func @torch.aten.expand(%arg0: !torch.vtensor<[1,2],f32>) -> !torch.vtensor<[3,2],f32> {
+  %int3 = torch.constant.int 3
+  %int2 = torch.constant.int 2
+  %0 = torch.prim.ListConstruct %int3, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %false = torch.constant.bool false
+  %1 = torch.aten.expand %arg0, %0, %false : !torch.vtensor<[1,2],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,2],f32>
+  return %1 : !torch.vtensor<[3,2],f32>
+}

--- a/test/Conversion/TorchToTcp/misc.mlir
+++ b/test/Conversion/TorchToTcp/misc.mlir
@@ -328,17 +328,15 @@ func.func @torch.aten.size.int(%arg0: !torch.vtensor<[?,?],f32>) -> () {
 // CHECK-LABEL:  @torch.aten.expand(
 // CHECK-SAME:   %[[ARG:.*]]: !torch.vtensor<[1,2],f32>) -> !torch.vtensor<[3,2],f32> {
 // CHECK:        %[[TENSOR:.*]] = torch_c.to_builtin_tensor %[[ARG]] : !torch.vtensor<[1,2],f32> -> tensor<1x2xf32>
-// CHECK:        %[[CONSTANT3:.*]] = torch.constant.int 3
-// CHECK:        %[[CONSTANT2:.*]] = torch.constant.int 2
-// CHECK:        %[[CAST0:.*]] = torch_c.to_i64 %[[CONSTANT3]]
+// CHECK:        %[[CONSTANT0:.*]] = torch.constant.int 3
+// CHECK:        %[[CONSTANT1:.*]] = torch.constant.int -1
+// CHECK:        %[[CAST0:.*]] = torch_c.to_i64 %[[CONSTANT0]]
 // CHECK:        %[[BROADCAST_DIM0:.*]] = arith.index_cast %[[CAST0]] : i64 to index
-// CHECK:        %[[CAST1:.*]] = torch_c.to_i64 %[[CONSTANT2]]
-// CHECK:        %[[BROADCAST_DIM1:.*]] = arith.index_cast %[[CAST1]] : i64 to index
-// CHECK:        %{{.*}} = tcp.broadcast %[[TENSOR]], %[[BROADCAST_DIM0]], %[[BROADCAST_DIM1]] {axes = [0, 1]} : tensor<1x2xf32>, index, index -> tensor<3x2xf32>
+// CHECK:        %{{.*}} = tcp.broadcast %[[TENSOR]], %[[BROADCAST_DIM0]] {axes = [0]} : tensor<1x2xf32>, index -> tensor<3x2xf32>
 func.func @torch.aten.expand(%arg0: !torch.vtensor<[1,2],f32>) -> !torch.vtensor<[3,2],f32> {
   %int3 = torch.constant.int 3
-  %int2 = torch.constant.int 2
-  %0 = torch.prim.ListConstruct %int3, %int2 : (!torch.int, !torch.int) -> !torch.list<int>
+  %int-1 = torch.constant.int -1
+  %0 = torch.prim.ListConstruct %int3, %int-1 : (!torch.int, !torch.int) -> !torch.list<int>
   %false = torch.constant.bool false
   %1 = torch.aten.expand %arg0, %0, %false : !torch.vtensor<[1,2],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,2],f32>
   return %1 : !torch.vtensor<[3,2],f32>

--- a/test/Conversion/TorchToTcp/misc.mlir
+++ b/test/Conversion/TorchToTcp/misc.mlir
@@ -322,3 +322,6 @@ func.func @torch.aten.size.int(%arg0: !torch.vtensor<[?,?],f32>) -> () {
   %0 = torch.aten.size.int %arg0, %int0 : !torch.vtensor<[?,?],f32>, !torch.int -> !torch.int
   return
 }
+
+// -----
+


### PR DESCRIPTION
`torch.broadcast_to` when exported using dynamo generates an `aten.expand` op (not `aten.broadcast_to`):
```ll
module {                                                                                                                                                                                          
  func.func @func_main(%arg0: !torch.vtensor<[1,2],f32>) -> !torch.vtensor<[3,2],f32> {                                                                                                           
    %int3 = torch.constant.int 3                                                                                                                                                                  
    %int2 = torch.constant.int 2                                                                                                                                                                  
    %0 = torch.prim.ListConstruct %int3, %int2 : (!torch.int, !torch.int) -> !torch.list<int>                                                                                                     
    %false = torch.constant.bool false                                                                                                                                                            
    %1 = torch.aten.expand %arg0, %0, %false : !torch.vtensor<[1,2],f32>, !torch.list<int>, !torch.bool -> !torch.vtensor<[3,2],f32>                                                              
    return %1 : !torch.vtensor<[3,2],f32>                                                                                                                                                         
  }                                                                                                                                                                                               
}  
```

This PR adds conversion of `aten.expand` to `tcp.broadcast` and onboards to AOT compile+execute framework. The test is disabled from CI right now, since it fails as it stands today. Validated that it passes with @AaronStGeorge 's fixes (https://github.com/cruise-automation/mlir-tcp/pull/62), pretty cool that Aaron caught this downstream, and we would've caught it much earlier if we had the AOT framework sooner :) 
```
bazel-out/k8-fastbuild/bin/test/AotCompile/_internal_broadcast_to_execute_test.cpp:139: Failure                                                                                                   
Expected equality of these values:                                                                                                                                                                
  Result.Output0.data[i]                                                                                                                                                                          
    Which is: 1.3712965                                                                                                                                                                           
  refOutput0.data<float>()[i]                                                                                                                                                                     
    Which is: 1.6557889                                                                                                                                                                           
                                                                                                                                                                                                  
bazel-out/k8-fastbuild/bin/test/AotCompile/_internal_broadcast_to_execute_test.cpp:139: Failure                                                                                                   
Expected equality of these values:                                                                                                                                                                
  Result.Output0.data[i]                                                                                                                                                                          
    Which is: 1.3712965                                                                                                                                                                           
  refOutput0.data<float>()[i]                                                                                                                                                                     
    Which is: 1.6557889          
```