### PR TITLE
Add ops for rounding

### DIFF
--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -389,6 +389,44 @@ def Tcp_FloorOp : Tcp_UnaryElementwiseOp<"floor", [SameOperandsAndResultElementT
   let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
 }
 
+def Tcp_RoundOp : Tcp_UnaryElementwiseOp<"round", [SameOperandsAndResultElementType]> {
+  let summary = "Computes elementwise rounding of input, with ties rounded away from zero";
+
+  let description = [{
+    Computes elementwise rounding of the input float tensor to the nearest integer value
+    in float, with halfway values rounded away from zero.
+  }];
+
+  let arguments = (ins
+    Tcp_FloatTensor:$in
+  );
+
+  let results = (outs
+    Tcp_FloatTensor:$out
+  );
+
+  let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
+}
+
+def Tcp_RoundEvenOp : Tcp_UnaryElementwiseOp<"round_even", [SameOperandsAndResultElementType]> {
+  let summary = "Computes elementwise rounding of input, with ties rounded to nearest even";
+
+  let description = [{
+    Computes elementwise rounding of the input float tensor to the nearest integer value
+    in float, with halfway values rounded to the nearest even integer.
+  }];
+
+  let arguments = (ins
+    Tcp_FloatTensor:$in
+  );
+
+  let results = (outs
+    Tcp_FloatTensor:$out
+  );
+
+  let assemblyFormat = "$in attr-dict `:` type($in) `->` type($out)";
+}
+
 def Tcp_CosOp : Tcp_UnaryElementwiseOp<"cos", [SameOperandsAndResultElementType]> {
   let summary = "Computes cosine of input, elementwise";
 

--- a/lib/Conversion/TcpToLinalg/Elementwise.cpp
+++ b/lib/Conversion/TcpToLinalg/Elementwise.cpp
@@ -119,6 +119,14 @@ createLinalgPayloadForElementwiseOp(Operation *op,
     return {b.create<math::FloorOp>(loc, payloadArgs[0])};
   }
 
+  if (isa<RoundOp>(op)) {
+    return {b.create<math::RoundOp>(loc, payloadArgs[0])};
+  }
+
+  if (isa<RoundEvenOp>(op)) {
+    return {b.create<math::RoundEvenOp>(loc, payloadArgs[0])};
+  }
+
   if (isa<SinOp>(op)) {
     return {b.create<math::SinOp>(loc, payloadArgs[0])};
   }
@@ -328,6 +336,8 @@ void mlir::TcpToLinalg::populateElementwisePatternsAndLegality(
   INSERT_TCP_TO_LINALG_PATTERN(SqrtOp);
   INSERT_TCP_TO_LINALG_PATTERN(CeilOp);
   INSERT_TCP_TO_LINALG_PATTERN(FloorOp);
+  INSERT_TCP_TO_LINALG_PATTERN(RoundOp);
+  INSERT_TCP_TO_LINALG_PATTERN(RoundEvenOp);
   INSERT_TCP_TO_LINALG_PATTERN(SinOp);
   INSERT_TCP_TO_LINALG_PATTERN(CosOp);
   INSERT_TCP_TO_LINALG_PATTERN(AbsOp);

--- a/lib/Conversion/TorchToTcp/Elementwise.cpp
+++ b/lib/Conversion/TorchToTcp/Elementwise.cpp
@@ -722,6 +722,7 @@ void torch_to_tcp::populateElementwisePatternsAndLegality(
       typeConverter, patterns, target, convertTorchOpsSet)
   INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenCeilOp, tcp::CeilOp);
   INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenFloorOp, tcp::FloorOp);
+  INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenRoundOp, tcp::RoundEvenOp);
   INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenSigmoidOp, tcp::SigmoidOp);
   INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenTanhOp, tcp::TanhOp);
   INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenSinOp, tcp::SinOp);

--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -21,6 +21,7 @@ AOT_TEST_SUITE = [
     ("tanh", False),
     ("clamp", False),
     ("relu", False),
+    ("round_even", False),
     ("sqrt_float", False),
     ("sqrt_int", False),
     ("concat_float_tensors", False),

--- a/test/AotCompile/basic_tcp_ops.mlir
+++ b/test/AotCompile/basic_tcp_ops.mlir
@@ -1,4 +1,4 @@
-func.func @func_1(%arg0: tensor<?x?xf32>,
+func.func @func_add_mul_1(%arg0: tensor<?x?xf32>,
                   %arg1: tensor<?x?xf32>,
                   %arg2: tensor<?x?xf32>) -> tensor<?x?xf32> {
   %0 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
@@ -6,7 +6,7 @@ func.func @func_1(%arg0: tensor<?x?xf32>,
   return %1 : tensor<?x?xf32>
 }
 
-func.func @func_2(%arg0: tensor<?x?xf32>,
+func.func @func_add_mul_2(%arg0: tensor<?x?xf32>,
                   %arg1: tensor<?x?xf32>,
                   %arg2: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
   %0 = tcp.add %arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
@@ -14,7 +14,7 @@ func.func @func_2(%arg0: tensor<?x?xf32>,
   return %0, %1 : tensor<?x?xf32>, tensor<?x?xf32>
 }
 
-func.func @func_3(%arg0: tensor<f32>,
+func.func @func_broadcast_add(%arg0: tensor<f32>,
                   %arg1: tensor<?xf32>) -> tensor<?xf32> {
   %c0 = arith.constant 0 : index
   %dim = tensor.dim %arg1, %c0 : tensor<?xf32>
@@ -22,4 +22,9 @@ func.func @func_3(%arg0: tensor<f32>,
   %arg0_bcast = tcp.broadcast %arg0_ex, %dim {axes = [0]} : tensor<1xf32>, index -> tensor<?xf32>
   %0 = tcp.add %arg0_bcast, %arg1 : tensor<?xf32>, tensor<?xf32> -> tensor<?xf32>
   return %0 : tensor<?xf32>
+}
+
+func.func @func_round(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.round %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
 }

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -313,6 +313,30 @@ def relu_loader() -> TorchLoaderOutput:
     )
 
 
+def round_even_loader() -> TorchLoaderOutput:
+    class RoundEven(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.round(x)
+
+    # Sample inputs
+    x = torch.randn(2, 3)
+
+    # Dynamic dim constraints
+    batch = Dim("batch")
+    dynamic_shapes = {
+        "x": {0: batch},
+    }
+
+    return TorchLoaderOutput(
+        model=RoundEven(),
+        inputs=(x,),
+        dynamic_shapes=dynamic_shapes,
+    )
+
+
 def sqrt_float_loader() -> TorchLoaderOutput:
     class SqrtFloat(torch.nn.Module):
         def __init__(self):

--- a/test/Conversion/TcpToLinalg/unary.mlir
+++ b/test/Conversion/TcpToLinalg/unary.mlir
@@ -171,6 +171,60 @@ func.func @floor(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
 
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
 
+// CHECK-LABEL: func.func @round(
+// CHECK-SAME:                %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK:         %[[CONST0:.*]] = arith.constant 0 : index
+// CHECK:         %[[DIM0:.*]] = tensor.dim %[[ARG]], %[[CONST0]] : tensor<?x?xf32>
+// CHECK:         %[[CONST1:.*]] = arith.constant 1 : index
+// CHECK:         %[[DIM1:.*]] = tensor.dim %[[ARG]], %[[CONST1]] : tensor<?x?xf32>
+// CHECK:         %[[EMPTY_TENSOR:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
+// CHECK:         %[[GENERIC:.*]] = linalg.generic {
+// CHECK-SAME:                        indexing_maps = [#[[MAP]], #[[MAP]]],
+// CHECK-SAME:                        iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME:                        ins(%[[ARG]] :  tensor<?x?xf32>)
+// CHECK-SAME:                        outs(%[[EMPTY_TENSOR]] : tensor<?x?xf32>) {
+// CHECK:         ^bb0(%[[BBARG0:.*]]: f32, %{{.*}}: f32):
+// CHECK:           %[[CEIL:.*]] = math.round %[[BBARG0]] : f32
+// CHECK:           linalg.yield %[[CEIL]] : f32
+// CHECK:         } -> tensor<?x?xf32>
+// CHECK:         return %[[GENERIC]] : tensor<?x?xf32>
+// CHECK:       }
+func.func @round(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.round %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK-LABEL: func.func @round_even(
+// CHECK-SAME:                %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
+// CHECK:         %[[CONST0:.*]] = arith.constant 0 : index
+// CHECK:         %[[DIM0:.*]] = tensor.dim %[[ARG]], %[[CONST0]] : tensor<?x?xf32>
+// CHECK:         %[[CONST1:.*]] = arith.constant 1 : index
+// CHECK:         %[[DIM1:.*]] = tensor.dim %[[ARG]], %[[CONST1]] : tensor<?x?xf32>
+// CHECK:         %[[EMPTY_TENSOR:.*]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xf32>
+// CHECK:         %[[GENERIC:.*]] = linalg.generic {
+// CHECK-SAME:                        indexing_maps = [#[[MAP]], #[[MAP]]],
+// CHECK-SAME:                        iterator_types = ["parallel", "parallel"]}
+// CHECK-SAME:                        ins(%[[ARG]] :  tensor<?x?xf32>)
+// CHECK-SAME:                        outs(%[[EMPTY_TENSOR]] : tensor<?x?xf32>) {
+// CHECK:         ^bb0(%[[BBARG0:.*]]: f32, %{{.*}}: f32):
+// CHECK:           %[[CEIL:.*]] = math.roundeven %[[BBARG0]] : f32
+// CHECK:           linalg.yield %[[CEIL]] : f32
+// CHECK:         } -> tensor<?x?xf32>
+// CHECK:         return %[[GENERIC]] : tensor<?x?xf32>
+// CHECK:       }
+func.func @round_even(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.round_even %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0, d1)>
+
 // CHECK-LABEL: func.func @sin(
 // CHECK-SAME:                %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32> {
 // CHECK:         %[[CONST0:.*]] = arith.constant 0 : index

--- a/test/Conversion/TorchToTcp/elementwise.mlir
+++ b/test/Conversion/TorchToTcp/elementwise.mlir
@@ -367,6 +367,19 @@ func.func @torch.aten.floor(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.round(
+// CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+// CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
+// CHECK:         %[[T1:.*]] = tcp.round_even %[[T0]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         %[[T2:.*]] = torch_c.from_builtin_tensor %[[T1]] : tensor<?x?xf32> -> !torch.vtensor<[?,?],f32>
+// CHECK:         return %[[T2]] : !torch.vtensor<[?,?],f32>
+func.func @torch.aten.round(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.round %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.sin(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>

--- a/test/Dialect/unary.mlir
+++ b/test/Dialect/unary.mlir
@@ -109,6 +109,28 @@ func.func @test_floor_f32(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
 
 // -----
 
+// CHECK-LABEL: func.func @test_round_f32(
+// CHECK-SAME:               %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[ROUND:.*]] = tcp.round %[[ARG]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         return %[[ROUND]] : tensor<?x?xf32>
+func.func @test_round_f32(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.round %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @test_round_even_f32(
+// CHECK-SAME:               %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:         %[[ROUND:.*]] = tcp.round_even %[[ARG]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:         return %[[ROUND]] : tensor<?x?xf32>
+func.func @test_round_even_f32(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = tcp.round_even %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @test_sin_f32(
 // CHECK-SAME:               %[[ARG:.*]]: tensor<?x?xf32>) -> tensor<?x?xf32>
 // CHECK:         %[[SIN:.*]] = tcp.sin %[[ARG]] : tensor<?x?xf32> -> tensor<?x?xf32>


### PR DESCRIPTION
This PR adds two Tcp ops for rounding.

`tcp.round` - rounds the input value, with halfway cases rounded away from zero.
`tcp.round_even` - rounds in the input value, with halfway cases rounded to the nearest even integer.

This PR includes the following:
* The definition of the two ops in Tcp for rounding.
* Lowering from TorchToTcp for the `torch.round` op.
* Lowerings from TcpToLinalg for both the Tcp rounding ops.
* Lit tests for the ops and their lowerings.
* AOT tests for both the Tcp rounding ops.

Since `torch.round` rounds halfway cases to even, it maps directly to `tcp.round_even`. There is no direct way to represent the other case (rounding away from zero) in PyTorch. 

The AOT test for `tcp.round_even` is through `torch.round`, whereas the AOT test for `tcp.round` is from a Tcp IR representation.