### PR TITLE
[TorchToTcp] Mark torch ops with non-fp inputs dynamically legal

### DIFF
--- a/lib/Conversion/TorchToTcp/Elementwise.cpp
+++ b/lib/Conversion/TorchToTcp/Elementwise.cpp
@@ -716,6 +716,10 @@ void torch_to_tcp::populateElementwisePatternsAndLegality(
   INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN(ConvertAtenDivOp, AtenDivScalarOp);
 #undef INSERT_ATEN_ELEMENTWISE_MUL_DIV_PATTERN
 
+// We only convert torch ops with fp inputs here. Hence marking torch ops
+// with non-fp inputs as dynamically legal (in Torch dialect) i.e. leave
+// them in Torch, to be handled by Torch -> TOSA later. This helps avoid
+// legalization errors after Torch -> TCP.
 #define INSERT_ATEN_UNARY_FP_ONLY_PATTERN(AtenOp, TcpOp)                       \
   {                                                                            \
     auto isFpOnlyOp = [](AtenOp op) {                                          \

--- a/test/Conversion/TorchToTcp/elementwise.mlir
+++ b/test/Conversion/TorchToTcp/elementwise.mlir
@@ -13,6 +13,15 @@ func.func @torch.aten.sigmoid(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtenso
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.sigmoid$int(
+// CHECK:         %0 = torch.aten.sigmoid %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+func.func @torch.aten.sigmoid$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.sigmoid %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.addtensor$samerank(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>, %[[ARG1:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
@@ -301,6 +310,15 @@ func.func @torch.aten.tanh(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.tanh$int(
+// CHECK:         %0 = torch.aten.tanh %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+func.func @torch.aten.tanh$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.tanh %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.relu(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
@@ -354,6 +372,15 @@ func.func @torch.aten.ceil(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.ceil$int(
+// CHECK:         %0 = torch.aten.ceil %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+func.func @torch.aten.ceil$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],si64> {
+  %0 = torch.aten.ceil %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+  return %0 : !torch.vtensor<[?,?],si64>
+}
+
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.floor(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
@@ -363,6 +390,15 @@ func.func @torch.aten.ceil(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[
 func.func @torch.aten.floor(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
   %0 = torch.aten.floor %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
   return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.floor$int(
+// CHECK:         %0 = torch.aten.floor %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+func.func @torch.aten.floor$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],si64> {
+  %0 = torch.aten.floor %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+  return %0 : !torch.vtensor<[?,?],si64>
 }
 
 // -----
@@ -380,6 +416,15 @@ func.func @torch.aten.round(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.round$int(
+// CHECK:         %0 = torch.aten.round %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+func.func @torch.aten.round$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],si64> {
+  %0 = torch.aten.round %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+  return %0 : !torch.vtensor<[?,?],si64>
+}
+
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.sin(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
@@ -393,6 +438,15 @@ func.func @torch.aten.sin(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.sin$int(
+// CHECK:         %0 = torch.aten.sin %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+func.func @torch.aten.sin$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.sin %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.cos(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
@@ -401,6 +455,15 @@ func.func @torch.aten.sin(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?
 // CHECK:         return %[[T2]] : !torch.vtensor<[?,?],f32>
 func.func @torch.aten.cos(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
   %0 = torch.aten.cos %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.cos$int(
+// CHECK:         %0 = torch.aten.cos %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+func.func @torch.aten.cos$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.cos %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
   return %0 : !torch.vtensor<[?,?],f32>
 }
 
@@ -432,6 +495,15 @@ func.func @torch.aten.log(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?
 
 // -----
 
+// CHECK-LABEL:  func.func @torch.aten.log$int(
+// CHECK:         %0 = torch.aten.log %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+func.func @torch.aten.log$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.log %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
 // CHECK-LABEL:  func.func @torch.aten.neg(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
 // CHECK:         %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,?],f32> -> tensor<?x?xf32>
@@ -441,6 +513,15 @@ func.func @torch.aten.log(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?
 func.func @torch.aten.neg(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
   %0 = torch.aten.neg %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
   return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.neg$int(
+// CHECK:         %0 = torch.aten.neg %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+func.func @torch.aten.neg$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],si64> {
+  %0 = torch.aten.neg %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],si64>
+  return %0 : !torch.vtensor<[?,?],si64>
 }
 
 // -----
@@ -594,6 +675,15 @@ func.func @torch.aten.atan2$rank0(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torc
 // CHECK:         return %[[T2]] : !torch.vtensor<[?,?],f32>
 func.func @torch.aten.atan(%arg0: !torch.vtensor<[?,?],f32>) -> !torch.vtensor<[?,?],f32> {
   %0 = torch.aten.atan %arg0 : !torch.vtensor<[?,?],f32> -> !torch.vtensor<[?,?],f32>
+  return %0 : !torch.vtensor<[?,?],f32>
+}
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.atan$int(
+// CHECK:         %0 = torch.aten.atan %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
+func.func @torch.aten.atan$int(%arg0: !torch.vtensor<[?,?],si64>) -> !torch.vtensor<[?,?],f32> {
+  %0 = torch.aten.atan %arg0 : !torch.vtensor<[?,?],si64> -> !torch.vtensor<[?,?],f32>
   return %0 : !torch.vtensor<[?,?],f32>
 }
 


### PR DESCRIPTION
This helps avoid legalization errors after Torch -> Tcp, for ops like `aten.neg` and `aten.sigmoid` with integer inputs, that do not convert to Tcp (due to type restrictions) and fail legalization, preventing further dialect conversions (to Tosa for instance).