### PR TITLE
Add tcp.slice op

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -188,6 +188,7 @@ cc_library(
         ":StablehloToTcp",
         ":TcpToArith",
         ":TcpToLinalg",
+        ":TcpToTensor",
         ":TorchToTcp",
     ],
 )
@@ -283,6 +284,27 @@ cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+cc_library(
+    name = "TcpToTensor",
+    srcs = [
+        "lib/Conversion/PassDetail.h",
+        "lib/Conversion/TcpToTensor/TcpToTensor.cpp",
+    ],
+    hdrs = ["include/mlir-tcp/Conversion/TcpToTensor/TcpToTensor.h"],
+    strip_include_prefix = "include",
+    deps = [
+        ":TcpConversionPassesIncGen",
+        ":TcpDialect",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:Dialect",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:Transforms",
     ],
 )

--- a/include/mlir-tcp/Conversion/Passes.td
+++ b/include/mlir-tcp/Conversion/Passes.td
@@ -97,4 +97,21 @@ def ConvertTcpToArith
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// TcpToTensor
+//===----------------------------------------------------------------------===//
+
+def ConvertTcpToTensor
+      : Pass<"convert-tcp-to-tensor", "func::FuncOp"> {
+  let summary = "Lower TCP to Tensor";
+  let description = [{
+    Pass that converts TCP operations to equivalent operations in Tensor.
+  }];
+
+  let constructor = "mlir::tcp::createConvertTcpToTensorPass()";
+  let dependentDialects = [
+    "mlir::tensor::TensorDialect",
+  ];
+}
+
 #endif // TCP_CONVERSION_PASSES

--- a/include/mlir-tcp/Conversion/TcpToTensor/TcpToTensor.h
+++ b/include/mlir-tcp/Conversion/TcpToTensor/TcpToTensor.h
@@ -9,17 +9,17 @@
 
 #pragma once
 
-#include "mlir-tcp/Dialect/IR/TcpDialect.h"
-
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
 
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DECL_CONVERTTCPTOTENSOR
 #include "mlir-tcp/Conversion/Passes.h.inc"
 
-} // end namespace mlir
+namespace tcp {
+
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTcpToTensorPass();
+
+} // namespace tcp
+} // namespace mlir

--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -618,4 +618,26 @@ def Tcp_GatherOp : Tcp_Op<"gather", [Pure, AllElementTypesMatch<["input", "out"]
   let assemblyFormat = "$input `,` $indices attr-dict `:` type($input) `,` type($indices) `->` type($out)";
 }
 
+def Tcp_SliceOp : Tcp_Op<"slice", [Pure, AllElementTypesMatch<["in", "out"]>, SameVariadicOperandSize]> {
+
+  let summary = "Extracts a slice of the input tensor";
+
+  let description = [{
+    Extracts a slice of the input tensor based on the given starts, sizes, and strides.
+  }];
+
+  let arguments = (ins
+    Tcp_Tensor:$in,
+    Variadic<Index>:$starts,
+    Variadic<Index>:$sizes,
+    Variadic<Index>:$strides
+  );
+
+  let results = (outs
+    Tcp_Tensor:$out
+  );
+
+  let assemblyFormat = "$in `(` $starts `)` `(` $sizes `)` `(` $strides `)` attr-dict `:` type($in) `->` type($out)";
+}
+
 #endif // TCP_OPS

--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -637,7 +637,7 @@ def Tcp_SliceOp : Tcp_Op<"slice", [Pure, AllElementTypesMatch<["in", "out"]>, Sa
     Tcp_Tensor:$out
   );
 
-  let assemblyFormat = "$in `(` $starts `)` `(` $sizes `)` `(` $strides `)` attr-dict `:` type($in) `->` type($out)";
+  let assemblyFormat = "$in `starts` `(` $starts `)` `sizes` `(` $sizes `)` `strides` `(` $strides `)` attr-dict `:` type($in) `->` type($out)";
 }
 
 #endif // TCP_OPS

--- a/lib/Conversion/Passes.cpp
+++ b/lib/Conversion/Passes.cpp
@@ -12,6 +12,7 @@
 #include "mlir-tcp/Conversion/StablehloToTcp/StablehloToTcp.h"
 #include "mlir-tcp/Conversion/TcpToArith/TcpToArith.h"
 #include "mlir-tcp/Conversion/TcpToLinalg/TcpToLinalg.h"
+#include "mlir-tcp/Conversion/TcpToTensor/TcpToTensor.h"
 #include "mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h"
 #include "mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h"
 

--- a/lib/Conversion/TcpToTensor/TcpToTensor.cpp
+++ b/lib/Conversion/TcpToTensor/TcpToTensor.cpp
@@ -1,0 +1,81 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir-tcp/Conversion/TcpToTensor/TcpToTensor.h"
+
+#include "mlir-tcp/Dialect/IR/TcpDialect.h"
+#include "mlir-tcp/Dialect/IR/TcpOps.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+
+#define GEN_PASS_DEF_CONVERTTCPTOTENSOR
+#include "mlir-tcp/Conversion/Passes.h.inc"
+
+namespace tcp {
+
+namespace {
+
+class SliceOpConverter : public OpConversionPattern<tcp::SliceOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tcp::SliceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto sliceOp = rewriter.create<tensor::ExtractSliceOp>(
+        op.getLoc(), adaptor.getIn(), getAsOpFoldResult(adaptor.getStarts()),
+        getAsOpFoldResult(adaptor.getSizes()),
+        getAsOpFoldResult(adaptor.getStrides()));
+    rewriter.replaceOp(op, sliceOp.getResult());
+    return success();
+  }
+};
+
+void populateTcpToTensorPatternsAndLegality(RewritePatternSet &patterns,
+                                            ConversionTarget &target) {
+  MLIRContext *context = patterns.getContext();
+
+  target.addIllegalOp<tcp::SliceOp>();
+  patterns.add<SliceOpConverter>(context);
+}
+
+class ConvertTcpToTensor : public ConvertTcpToTensorBase<ConvertTcpToTensor> {
+public:
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ConversionTarget target(*context);
+    target.addLegalDialect<mlir::tensor::TensorDialect>();
+
+    RewritePatternSet patterns(context);
+    populateTcpToTensorPatternsAndLegality(patterns, target);
+
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>> createConvertTcpToTensorPass() {
+  return std::make_unique<ConvertTcpToTensor>();
+}
+
+} // namespace tcp
+} // namespace mlir

--- a/lib/Conversion/TorchToTcp/DataMovement.cpp
+++ b/lib/Conversion/TorchToTcp/DataMovement.cpp
@@ -184,13 +184,10 @@ public:
     if (failed(verifyLinalgCompatibleTypes(op, rewriter)))
       return failure();
 
-    Location loc = op.getLoc();
-    const TypeConverter *typeConverter = getTypeConverter();
-
     auto input = adaptor.getSelf();
-    RankedTensorType resultType =
-        typeConverter->convertType(op->getResult(0).getType())
-            .cast<RankedTensorType>();
+    RankedTensorType resultType = getTypeConverter()
+                                      ->convertType(op->getResult(0).getType())
+                                      .cast<RankedTensorType>();
 
     SmallVector<Value> resultShape;
     SmallVector<Value> offsets;
@@ -201,10 +198,8 @@ public:
       return failure();
     }
 
-    Value result = rewriter.create<tensor::ExtractSliceOp>(
-        loc, input, offsets, resultShape, strides);
-
-    rewriter.replaceOpWithNewOp<tensor::CastOp>(op, resultType, result);
+    rewriter.replaceOpWithNewOp<tcp::SliceOp>(op, resultType, input, offsets,
+                                              resultShape, strides);
     return success();
   }
 };

--- a/lib/Pipeline/Pipeline.cpp
+++ b/lib/Pipeline/Pipeline.cpp
@@ -11,6 +11,7 @@
 
 #include "mlir-tcp/Conversion/TcpToArith/TcpToArith.h"
 #include "mlir-tcp/Conversion/TcpToLinalg/TcpToLinalg.h"
+#include "mlir-tcp/Conversion/TcpToTensor/TcpToTensor.h"
 #include "mlir-tcp/Conversion/TorchToTcp/TorchToTcp.h"
 #include "mlir-tcp/Conversion/TorchToTcp/TorchToTcpCustomOp.h"
 #include "mlir-tcp/Dialect/Transforms/TransformTensorOps.h"
@@ -67,6 +68,7 @@ static void createTcpToLlvmPipeline(OpPassManager &pm) {
 
   // TCP -> Linalg/Arith conversions.
   pm.addNestedPass<func::FuncOp>(tcp::createConvertTcpToLinalgPass());
+  pm.addNestedPass<func::FuncOp>(tcp::createConvertTcpToTensorPass());
   pm.addNestedPass<func::FuncOp>(tcp::createConvertTcpToArithPass());
 
   // Bufferize tensor -> memref.

--- a/test/Conversion/TcpToTensor/data_movement.mlir
+++ b/test/Conversion/TcpToTensor/data_movement.mlir
@@ -1,0 +1,21 @@
+// RUN: tcp-opt %s -split-input-file -verify-diagnostics --convert-tcp-to-tensor | FileCheck %s
+
+// CHECK-LABEL: func.func @test_slice(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32>
+// CHECK:           %[[D1:.*]] = tensor.dim %[[ARG0]]
+// CHECK:           %[[D2:.*]] = tensor.dim %[[ARG0]]
+// CHECK:           %[[SLICE:.*]] = tensor.extract_slice %[[ARG0]]
+// CHECK-SAME:                           %[[D1]], %[[D2]]
+// CHECK-SAME:                           tensor<1x56x?x?xf32> to tensor<1x28x?x?xf32>
+// CHECK:           return %[[SLICE]] : tensor<1x28x?x?xf32>
+func.func @test_slice(%arg0: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32> {
+  %c28 = arith.constant 28 : index
+  %c3 = arith.constant 3 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c2 : tensor<1x56x?x?xf32>
+  %dim_0 = tensor.dim %arg0, %c3 : tensor<1x56x?x?xf32>
+  %1 = tcp.slice %arg0 ( %c0, %c0, %c0, %c0 ) ( %c1, %c28, %dim, %dim_0 ) ( %c1, %c2, %c1, %c1 ) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+  return %1 : tensor<1x28x?x?xf32>
+}

--- a/test/Conversion/TcpToTensor/data_movement.mlir
+++ b/test/Conversion/TcpToTensor/data_movement.mlir
@@ -16,6 +16,6 @@ func.func @test_slice(%arg0: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32> {
   %c0 = arith.constant 0 : index
   %dim = tensor.dim %arg0, %c2 : tensor<1x56x?x?xf32>
   %dim_0 = tensor.dim %arg0, %c3 : tensor<1x56x?x?xf32>
-  %1 = tcp.slice %arg0 ( %c0, %c0, %c0, %c0 ) ( %c1, %c28, %dim, %dim_0 ) ( %c1, %c2, %c1, %c1 ) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+  %1 = tcp.slice %arg0 starts( %c0, %c0, %c0, %c0 ) sizes( %c1, %c28, %dim, %dim_0 ) strides( %c1, %c2, %c1, %c1 ) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
   return %1 : tensor<1x28x?x?xf32>
 }

--- a/test/Conversion/TorchToTcp/data_movement.mlir
+++ b/test/Conversion/TorchToTcp/data_movement.mlir
@@ -18,9 +18,8 @@ func.func @torch.aten.cat(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtenso
 // CHECK-LABEL: @torch.aten.slice.Tensor
 //   CHECK-SAME:   %[[ARG0:.+]]: !torch.vtensor<[1,56,?,?],f32>) -> !torch.vtensor<[1,28,?,?],f32>
 //        CHECK:   %[[V1:.+]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[1,56,?,?],f32> -> tensor<1x56x?x?xf32>
-//        CHECK:   %[[V2:.+]] = tensor.extract_slice %[[V1]][%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] [%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}] : tensor<1x56x?x?xf32> to tensor<?x?x?x?xf32>
-//        CHECK:   %[[V3:.+]] = tensor.cast %[[V2]] : tensor<?x?x?x?xf32> to tensor<1x28x?x?xf32>
-//        CHECK:   %[[V4:.+]] = torch_c.from_builtin_tensor %[[V3]] : tensor<1x28x?x?xf32> -> !torch.vtensor<[1,28,?,?],f32>
+//        CHECK:   %[[V2:.+]] = tcp.slice %[[V1]](%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) (%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) (%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+//        CHECK:   %[[V3:.+]] = torch_c.from_builtin_tensor %[[V2]] : tensor<1x28x?x?xf32> -> !torch.vtensor<[1,28,?,?],f32>
 func.func @torch.aten.slice.Tensor(%arg0: !torch.vtensor<[1,56,?,?],f32>) -> !torch.vtensor<[1,28,?,?],f32> {
   %int100 = torch.constant.int 100
   %int1 = torch.constant.int 1

--- a/test/Conversion/TorchToTcp/data_movement.mlir
+++ b/test/Conversion/TorchToTcp/data_movement.mlir
@@ -18,7 +18,7 @@ func.func @torch.aten.cat(%arg0: !torch.vtensor<[?,?],f32>, %arg1: !torch.vtenso
 // CHECK-LABEL: @torch.aten.slice.Tensor
 //   CHECK-SAME:   %[[ARG0:.+]]: !torch.vtensor<[1,56,?,?],f32>) -> !torch.vtensor<[1,28,?,?],f32>
 //        CHECK:   %[[V1:.+]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[1,56,?,?],f32> -> tensor<1x56x?x?xf32>
-//        CHECK:   %[[V2:.+]] = tcp.slice %[[V1]](%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) (%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) (%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+//        CHECK:   %[[V2:.+]] = tcp.slice %[[V1]] starts(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) sizes(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) strides(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
 //        CHECK:   %[[V3:.+]] = torch_c.from_builtin_tensor %[[V2]] : tensor<1x28x?x?xf32> -> !torch.vtensor<[1,28,?,?],f32>
 func.func @torch.aten.slice.Tensor(%arg0: !torch.vtensor<[1,56,?,?],f32>) -> !torch.vtensor<[1,28,?,?],f32> {
   %int100 = torch.constant.int 100

--- a/test/Dialect/data_movement.mlir
+++ b/test/Dialect/data_movement.mlir
@@ -17,8 +17,8 @@ func.func @test_gather(%arg0 : tensor<?x?xf32>, %arg1 : tensor<2x?xi64>) -> tens
 // CHECK-SAME:          %[[ARG0:.*]]: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32>
 // CHECK:           %[[D1:.*]] = tensor.dim %[[ARG0]]
 // CHECK:           %[[D2:.*]] = tensor.dim %[[ARG0]]
-// CHECK:           %[[SLICE:.*]] = tcp.slice %[[ARG0]](%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) (%{{.*}}, %{{.*}}, %[[D1]], %[[D2]])
-// CHECK-SAME:                                (%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+// CHECK:           %[[SLICE:.*]] = tcp.slice %[[ARG0]] starts(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) sizes(%{{.*}}, %{{.*}}, %[[D1]], %[[D2]])
+// CHECK-SAME:                                strides(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
 // CHECK:           return %[[SLICE]] : tensor<1x28x?x?xf32>
 func.func @test_slice(%arg0: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32> {
   %c28 = arith.constant 28 : index
@@ -28,6 +28,6 @@ func.func @test_slice(%arg0: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32> {
   %c0 = arith.constant 0 : index
   %dim = tensor.dim %arg0, %c2 : tensor<1x56x?x?xf32>
   %dim_0 = tensor.dim %arg0, %c3 : tensor<1x56x?x?xf32>
-  %1 = tcp.slice %arg0 ( %c0, %c0, %c0, %c0 ) ( %c1, %c28, %dim, %dim_0 ) ( %c1, %c2, %c1, %c1 ) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+  %1 = tcp.slice %arg0 starts ( %c0, %c0, %c0, %c0 ) sizes ( %c1, %c28, %dim, %dim_0 ) strides ( %c1, %c2, %c1, %c1 ) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
   return %1 : tensor<1x28x?x?xf32>
 }

--- a/test/Dialect/data_movement.mlir
+++ b/test/Dialect/data_movement.mlir
@@ -10,3 +10,24 @@ func.func @test_gather(%arg0 : tensor<?x?xf32>, %arg1 : tensor<2x?xi64>) -> tens
                 tensor<?x?xf32>, tensor<2x?xi64> -> tensor<2x?xf32>
   return %0 : tensor<2x?xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @test_slice(
+// CHECK-SAME:          %[[ARG0:.*]]: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32>
+// CHECK:           %[[D1:.*]] = tensor.dim %[[ARG0]]
+// CHECK:           %[[D2:.*]] = tensor.dim %[[ARG0]]
+// CHECK:           %[[SLICE:.*]] = tcp.slice %[[ARG0]](%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) (%{{.*}}, %{{.*}}, %[[D1]], %[[D2]])
+// CHECK-SAME:                                (%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+// CHECK:           return %[[SLICE]] : tensor<1x28x?x?xf32>
+func.func @test_slice(%arg0: tensor<1x56x?x?xf32>) -> tensor<1x28x?x?xf32> {
+  %c28 = arith.constant 28 : index
+  %c3 = arith.constant 3 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c2 : tensor<1x56x?x?xf32>
+  %dim_0 = tensor.dim %arg0, %c3 : tensor<1x56x?x?xf32>
+  %1 = tcp.slice %arg0 ( %c0, %c0, %c0, %c0 ) ( %c1, %c28, %dim, %dim_0 ) ( %c1, %c2, %c1, %c1 ) : tensor<1x56x?x?xf32> -> tensor<1x28x?x?xf32>
+  return %1 : tensor<1x28x?x?xf32>
+}


### PR DESCRIPTION
This PR adds the `tcp.slice` op and the conversions needed for that op.

Specifically, this PR:
* Adds a new op in the Tcp dialect, `tcp.slice`.
* Updates the lowering of slice in TorchToTcp to create `tcp.slice`. Prior to this change, this lowering was emitting `tensor.extract_slice` instead.
* Adds a new lowering pass, `TcpToTensor`, which lowers `tcp.slice` to `tensor.extract_slice`.
* Adds unit tests and conversion tests for both the lowerings.
* Adds an e2e execution test that uses `tcp.slice`.