### PR TITLE
[Clangd] Add TcpToTensor to clangd targets

### DIFF
--- a/tools/clangd/BUILD
+++ b/tools/clangd/BUILD
@@ -22,6 +22,7 @@ refresh_compile_commands(
         "//:TcpOpsIncGen",
         "//:TcpToArith",
         "//:TcpToLinalg",
+        "//:TcpToTensor",
         "//:TcpTypesIncGen",
         "//:TorchToTcp",
         "//:tcp-opt",


### PR DESCRIPTION
This was recently added (by https://github.com/cruise-automation/mlir-tcp/pull/72). In the future, we'll look into automating the target list generation (possibly a GitHub Action).
