### PR TITLE
Tiling interface for slice op

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -102,10 +102,12 @@ cc_library(
     srcs = [
         "lib/Dialect/IR/TcpDialect.cpp",
         "lib/Dialect/IR/TcpOps.cpp",
+        "lib/Dialect/IR/TcpTilingInterfaceImpl.cpp",
     ],
     hdrs = [
         "include/mlir-tcp/Dialect/IR/TcpDialect.h",
         "include/mlir-tcp/Dialect/IR/TcpOps.h",
+        "include/mlir-tcp/Dialect/IR/TcpTilingInterfaceImpl.h",
     ],
     strip_include_prefix = "include",
     deps = [
@@ -113,7 +115,9 @@ cc_library(
         ":TcpTypesIncGen",
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",
+        "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:QuantOps",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -113,12 +113,12 @@ cc_library(
     deps = [
         ":TcpOpsIncGen",
         ":TcpTypesIncGen",
+        "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:Dialect",
         "@llvm-project//mlir:DialectUtils",
-        "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:FuncDialect",
-        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:QuantOps",
+        "@llvm-project//mlir:SCFDialect",
     ],
 )
 

--- a/include/mlir-tcp/Dialect/IR/TcpTilingInterfaceImpl.h
+++ b/include/mlir-tcp/Dialect/IR/TcpTilingInterfaceImpl.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace mlir {
+
+class DialectRegistry;
+
+namespace tcp {
+
+void registerTilingInterfaceExternalModels(DialectRegistry &registry);
+
+} // namespace tcp
+} // namespace mlir

--- a/include/mlir-tcp/Dialect/IR/TcpTilingInterfaceImpl.h
+++ b/include/mlir-tcp/Dialect/IR/TcpTilingInterfaceImpl.h
@@ -1,3 +1,12 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+//===----------------------------------------------------------------------===//
+
 #pragma once
 
 namespace mlir {

--- a/lib/Dialect/IR/TcpTilingInterfaceImpl.cpp
+++ b/lib/Dialect/IR/TcpTilingInterfaceImpl.cpp
@@ -1,0 +1,131 @@
+#include "mlir-tcp/Dialect/IR/TcpTilingInterfaceImpl.h"
+
+#include "mlir-tcp/Dialect/IR/TcpDialect.h"
+#include "mlir-tcp/Dialect/IR/TcpOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/Interfaces/TilingInterface.h"
+
+#include "llvm/Support/Debug.h"
+
+#include <numeric>
+
+using namespace mlir;
+using namespace mlir::tcp;
+
+namespace {
+
+struct SliceOpTiling
+    : public TilingInterface::ExternalModel<SliceOpTiling, tcp::SliceOp> {
+
+  SmallVector<utils::IteratorType> getLoopIteratorTypes(Operation *op) const {
+    // The iterator types describe the type of the loops in the
+    // loop-nest for the eventual tiled op. For the slice op, these are
+    // just parallel loops.
+    auto sliceOp = cast<tcp::SliceOp>(op);
+    return SmallVector(sliceOp.getType().getRank(),
+                       utils::IteratorType::parallel);
+  }
+
+  SmallVector<Range> getIterationDomain(Operation *op, OpBuilder &b) const {
+    // The iteration domain describes the loop bounds for the tiled
+    // operation.
+    auto sliceOp = cast<tcp::SliceOp>(op);
+    OpFoldResult zero = b.getIndexAttr(0);
+    OpFoldResult one = b.getIndexAttr(1);
+    SmallVector<Range> loopRanges(sliceOp.getType().getRank(),
+                                  {zero, one, one});
+    for (auto [idx, size] : llvm::enumerate(sliceOp.getSizes())) {
+      loopRanges[idx].offset = zero;
+      loopRanges[idx].size = size;
+    }
+    return loopRanges;
+  }
+
+  FailureOr<TilingResult>
+  getTiledImplementation(Operation *op, OpBuilder &b,
+                         ArrayRef<OpFoldResult> offsets,
+                         ArrayRef<OpFoldResult> sizes) const {
+    // getTiledImplementation and generateResultTileValue are the same
+    // because:
+    // 1. `getIterationDomain` returns a loop with zero offsets
+    //     and the result slice length
+    // 2. `getResultTilePosition` returns the same offsets and sizes as
+    //     the input offsets and slices.
+    // In other words, the body of the tiled implementation is
+    // computing the output at exactly offsets/sizes.
+    return generateResultTileValue(op, b, 0, offsets, sizes);
+  }
+
+  FailureOr<TilingResult>
+  generateResultTileValue(Operation *op, OpBuilder &b, unsigned resultNumber,
+                          ArrayRef<OpFoldResult> offsets,
+                          ArrayRef<OpFoldResult> sizes) const {
+
+    auto sliceOp = cast<tcp::SliceOp>(op);
+    auto loc = op->getLoc();
+
+    // TODO: How to handle strides from the sliceOp?
+    // Do we need to error out when strides != 1?
+    auto oneAttr = b.getI64IntegerAttr(1);
+    SmallVector<OpFoldResult> strides(offsets.size(), oneAttr);
+
+    auto fold = [&](OpFoldResult ofr) {
+      return getValueOrCreateConstantIndexOp(b, loc, ofr);
+    };
+    auto add = [&](OpFoldResult val1, OpFoldResult val2) {
+      return b.createOrFold<arith::AddIOp>(loc, fold(val1), fold(val2));
+    };
+    auto mul = [&](OpFoldResult val1, OpFoldResult val2) {
+      return b.createOrFold<arith::MulIOp>(loc, fold(val1), fold(val2));
+    };
+
+    auto sliceStart = sliceOp.getStarts();
+    auto sliceStrides = sliceOp.getStrides();
+    SmallVector<OpFoldResult> newOffsets;
+    for (auto [offset, start, stride] :
+         llvm::zip(offsets, sliceStart, sliceStrides)) {
+      newOffsets.push_back(add(start, mul(offset, stride)));
+    }
+
+    auto extractOp = b.create<tensor::ExtractSliceOp>(
+        loc, sliceOp.getIn(), newOffsets, sizes, strides);
+
+    // This extra redundant `tensor.extract_slice` is needed because the tiling
+    // algorithms expect that `generateResultTileValue` will return an
+    // op whose operands operate on slices of the original
+    // inputs. Without this, we'd need to make a small modification to
+    // the core tile and fuse algorithm in MLIR.
+    SmallVector<OpFoldResult> zeroOffsets(offsets.size(),
+                                          b.getI64IntegerAttr(0));
+    auto returnSliceOp = b.create<tensor::ExtractSliceOp>(
+        loc, extractOp.getResult(), zeroOffsets, sizes, strides);
+
+    return TilingResult{{returnSliceOp},
+                        SmallVector<Value>(returnSliceOp->getResults())};
+  }
+
+  LogicalResult
+  getResultTilePosition(Operation *op, OpBuilder &b, unsigned resultNumber,
+                        ArrayRef<OpFoldResult> offsets,
+                        ArrayRef<OpFoldResult> sizes,
+                        SmallVector<OpFoldResult> &resultOffsets,
+                        SmallVector<OpFoldResult> &resultSizes) const {
+    resultOffsets.assign(offsets.begin(), offsets.end());
+    resultSizes.assign(sizes.begin(), sizes.end());
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::tcp::registerTilingInterfaceExternalModels(
+    DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, TcpDialect *dialect) {
+    tcp::SliceOp::attachInterface<SliceOpTiling>(*ctx);
+  });
+}

--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -11,6 +11,7 @@
 
 #include "mlir-tcp/Conversion/Passes.h"
 #include "mlir-tcp/Dialect/IR/TcpDialect.h"
+#include "mlir-tcp/Dialect/IR/TcpTilingInterfaceImpl.h"
 #include "mlir-tcp/Dialect/Transforms/Passes.h"
 
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
@@ -22,6 +23,7 @@ void mlir::tcp::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<tcp::TcpDialect>();
   registry.insert<torch::Torch::TorchDialect>();
   mlir::func::registerInlinerExtension(registry);
+  mlir::tcp::registerTilingInterfaceExternalModels(registry);
 }
 
 void mlir::tcp::registerAllPasses() {

--- a/test/Dialect/structured_fuse.mlir
+++ b/test/Dialect/structured_fuse.mlir
@@ -34,7 +34,7 @@ func.func @fuse_tcp_slice(%arg0: tensor<40x40xf32>) -> tensor<32x32xf32> {
     %c3 = arith.constant 3 : index
     %c5 = arith.constant 5 : index
     %c1 = arith.constant 1 : index
-    %slice = tcp.slice %0 starts ( %c3, %c5 ) sizes ( %c32, %c16 ) strides ( %c1, %c1 ) : tensor<40x40xf32> -> tensor<32x32xf32>
+    %slice = tcp.slice %0 starts ( %c3, %c5 ) sizes ( %c32, %c32 ) strides ( %c1, %c1 ) : tensor<40x40xf32> -> tensor<32x32xf32>
 
     %shape = tensor.empty() : tensor<32x32xf32>
     %ret = linalg.elemwise_unary ins(%slice: tensor<32x32xf32>) outs(%shape: tensor<32x32xf32>) -> tensor<32x32xf32>
@@ -44,7 +44,6 @@ func.func @fuse_tcp_slice(%arg0: tensor<40x40xf32>) -> tensor<32x32xf32> {
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-    %slice = transform.structured.match ops{["tcp.slice"]} in %arg0 : (!transform.any_op) -> !transform.any_op
     %unary = transform.structured.match ops{["linalg.elemwise_unary"]} in %arg0 : (!transform.any_op) -> !transform.any_op
 
     %1, %loops:2 = transform.structured.fuse %unary {tile_sizes = [1, 1], tile_interchange = [0, 1]}
@@ -110,10 +109,133 @@ func.func @fuse_tcp_slice_stride2(%arg0: tensor<40x40xf32>) -> tensor<32x16xf32>
 
 module attributes {transform.with_named_sequence} {
   transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
-    %slice = transform.structured.match ops{["tcp.slice"]} in %arg0 : (!transform.any_op) -> !transform.any_op
     %unary = transform.structured.match ops{["linalg.elemwise_unary"]} in %arg0 : (!transform.any_op) -> !transform.any_op
 
     %1, %loops:2 = transform.structured.fuse %unary {tile_sizes = [1, 1], tile_interchange = [0, 1]}
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.op<"func.func">
+    transform.apply_patterns to %func_op {
+      transform.apply_patterns.tensor.fold_tensor_empty
+      transform.apply_patterns.tensor.fold_tensor_subset_ops
+    } : !transform.op<"func.func">
+
+    transform.yield
+  }
+}
+
+// -----
+
+// CHECK: func.func @fuse_tcp_slice_multiple(%[[ARG0:.+]]: tensor<40x40xf32>) -> tensor<16x16xf32> {
+// CHECK:   %[[C8:.+]] = arith.constant 8 : index
+// CHECK:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK:   %[[C1:.+]] = arith.constant 1 : index
+// CHECK:   %[[C16:.+]] = arith.constant 16 : index
+// CHECK:   %[[VAL0:.+]] = tensor.empty() : tensor<16x16xf32>
+// CHECK:   %[[VAL1:.+]] = scf.for %arg1 = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%arg2 = %[[VAL0]]) -> (tensor<16x16xf32>) {
+// CHECK:     %[[VAL2:.+]] = scf.for %arg3 = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%arg4 = %arg2) -> (tensor<16x16xf32>) {
+// CHECK:       %[[VAL3:.+]] = arith.addi %arg1, %[[C8]] : index
+// CHECK:       %[[VAL4:.+]] = arith.addi %arg3, %[[C8]] : index
+// CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[VAL3]], %[[VAL4]]] [1, 1] [1, 1] : tensor<40x40xf32> to tensor<1x1xf32>
+// CHECK:       %[[VAL5:.+]] = tensor.empty() : tensor<1x1xf32>
+// CHECK:       %[[VAL6:.+]] = linalg.elemwise_binary ins(%[[SLICE0]], %[[SLICE0]] : tensor<1x1xf32>, tensor<1x1xf32>) outs(%[[VAL5]] : tensor<1x1xf32>) -> tensor<1x1xf32>
+// CHECK:       %[[SLICE1:.+]] = tcp.slice %[[VAL6]] starts(%[[C0]], %[[C0]]) sizes(%[[C1]], %[[C1]]) strides(%[[C1]], %[[C1]]) : tensor<1x1xf32> -> tensor<1x1xf32>
+// CHECK:       %[[SLICE2:.+]] = tcp.slice %[[SLICE1]] starts(%[[C0]], %[[C0]]) sizes(%[[C1]], %[[C1]]) strides(%[[C1]], %[[C1]]) : tensor<1x1xf32> -> tensor<1x1xf32>
+// CHECK:       %[[SLICE3:.+]] = tensor.extract_slice %arg4[%arg1, %arg3] [1, 1] [1, 1] : tensor<16x16xf32> to tensor<1x1xf32>
+// CHECK:       %[[UNARY:.+]] = linalg.elemwise_unary ins(%[[SLICE2]] : tensor<1x1xf32>) outs(%[[SLICE3]] : tensor<1x1xf32>) -> tensor<1x1xf32>
+// CHECK:       %[[ISLICE:.+]] = tensor.insert_slice %[[UNARY]] into %arg4[%arg1, %arg3] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<16x16xf32>
+// CHECK:       scf.yield %[[ISLICE]] : tensor<16x16xf32>
+// CHECK:     }
+// CHECK:     scf.yield %[[VAL2]] : tensor<16x16xf32>
+// CHECK:   }
+// CHECK:   return %[[VAL1]] : tensor<16x16xf32>
+func.func @fuse_tcp_slice_multiple(%arg0: tensor<40x40xf32>) -> tensor<16x16xf32> {
+    %shape40 = tensor.empty() : tensor<40x40xf32>
+
+    %0 = linalg.elemwise_binary ins(%arg0, %arg0 : tensor<40x40xf32>, tensor<40x40xf32>)
+                             outs(%shape40: tensor<40x40xf32>) -> tensor<40x40xf32>
+
+    %c32 = arith.constant 32 : index
+    %c16 = arith.constant 16 : index
+    %c3 = arith.constant 3 : index
+    %c5 = arith.constant 5 : index
+    %c1 = arith.constant 1 : index
+    %slice = tcp.slice %0 starts ( %c3, %c5 ) sizes ( %c32, %c32 ) strides ( %c1, %c1 ) : tensor<40x40xf32> -> tensor<32x32xf32>
+    %slice2 = tcp.slice %slice starts ( %c5, %c3 ) sizes ( %c16, %c16 ) strides ( %c1, %c1 ) : tensor<32x32xf32> -> tensor<16x16xf32>
+
+    %shape = tensor.empty() : tensor<16x16xf32>
+    %ret = linalg.elemwise_unary ins(%slice2: tensor<16x16xf32>) outs(%shape: tensor<16x16xf32>) -> tensor<16x16xf32>
+
+    return %ret : tensor<16x16xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %unary = transform.structured.match ops{["linalg.elemwise_unary"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+
+    %1, %loops:2 = transform.structured.fuse %unary {tile_sizes = [1, 1], tile_interchange = [0, 1]}
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.op<"func.func">
+    transform.apply_patterns to %func_op {
+      transform.apply_patterns.tensor.fold_tensor_empty
+      transform.apply_patterns.tensor.fold_tensor_subset_ops
+    } : !transform.op<"func.func">
+
+    transform.yield
+  }
+}
+
+// -----
+
+// CHECK: func.func @fuse_tcp_slice_non_unit_tile(%[[ARG0:.+]]: tensor<40x40xf32>) -> tensor<32x32xf32> {
+// CHECK:   %[[C4:.+]] = arith.constant 4 : index
+// CHECK:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK:   %[[C1:.+]] = arith.constant 1 : index
+// CHECK:   %[[C5:.+]] = arith.constant 5 : index
+// CHECK:   %[[C3:.+]] = arith.constant 3 : index
+// CHECK:   %[[C32:.+]] = arith.constant 32 : index
+// CHECK:   %[[VAL0:.+]] = tensor.empty() : tensor<32x32xf32>
+// CHECK:   %[[VAL1:.+]] = scf.for %arg1 = %[[C0]] to %[[C32]] step %[[C4]] iter_args(%arg2 = %[[VAL0]]) -> (tensor<32x32xf32>) {
+// CHECK:     %[[VAL2:.+]] = scf.for %arg3 = %[[C0]] to %[[C32]] step %[[C4]] iter_args(%arg4 = %arg2) -> (tensor<32x32xf32>) {
+// CHECK:       %[[VAL3:.+]] = arith.addi %arg1, %[[C3]] : index
+// CHECK:       %[[VAL4:.+]] = arith.addi %arg3, %[[C5]] : index
+// CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[VAL3]], %[[VAL4]]] [4, 4] [1, 1] : tensor<40x40xf32> to tensor<4x4xf32>
+// CHECK:       %[[VAL5:.+]] = tensor.empty() : tensor<4x4xf32>
+// CHECK:       %[[VAL6:.+]] = linalg.elemwise_binary ins(%[[SLICE0]], %[[SLICE0]] : tensor<4x4xf32>, tensor<4x4xf32>) outs(%[[VAL5]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK:       %[[SLICE1:.+]] = tcp.slice %[[VAL6]] starts(%[[C0]], %[[C0]]) sizes(%[[C4]], %[[C4]]) strides(%[[C1]], %[[C1]]) : tensor<4x4xf32> -> tensor<4x4xf32>
+// CHECK:       %[[SLICE2:.+]] = tensor.extract_slice %arg4[%arg1, %arg3] [4, 4] [1, 1] : tensor<32x32xf32> to tensor<4x4xf32>
+// CHECK:       %[[UNARY:.+]] = linalg.elemwise_unary ins(%[[SLICE1]] : tensor<4x4xf32>) outs(%[[SLICE2]] : tensor<4x4xf32>) -> tensor<4x4xf32>
+// CHECK:       %[[ISLICE:.+]] = tensor.insert_slice %[[UNARY]] into %arg4[%arg1, %arg3] [4, 4] [1, 1] : tensor<4x4xf32> into tensor<32x32xf32>
+// CHECK:       scf.yield %[[ISLICE]] : tensor<32x32xf32>
+// CHECK:     }
+// CHECK:     scf.yield %[[VAL2]] : tensor<32x32xf32>
+// CHECK:   }
+// CHECK:   return %[[VAL1]] : tensor<32x32xf32>
+func.func @fuse_tcp_slice_non_unit_tile(%arg0: tensor<40x40xf32>) -> tensor<32x32xf32> {
+    %shape40 = tensor.empty() : tensor<40x40xf32>
+
+    %0 = linalg.elemwise_binary ins(%arg0, %arg0 : tensor<40x40xf32>, tensor<40x40xf32>)
+                             outs(%shape40: tensor<40x40xf32>) -> tensor<40x40xf32>
+
+    %c32 = arith.constant 32 : index
+    %c16 = arith.constant 16 : index
+    %c3 = arith.constant 3 : index
+    %c5 = arith.constant 5 : index
+    %c1 = arith.constant 1 : index
+    %slice = tcp.slice %0 starts ( %c3, %c5 ) sizes ( %c32, %c32 ) strides ( %c1, %c1 ) : tensor<40x40xf32> -> tensor<32x32xf32>
+
+    %shape = tensor.empty() : tensor<32x32xf32>
+    %ret = linalg.elemwise_unary ins(%slice: tensor<32x32xf32>) outs(%shape: tensor<32x32xf32>) -> tensor<32x32xf32>
+
+    return %ret : tensor<32x32xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %unary = transform.structured.match ops{["linalg.elemwise_unary"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+
+    %1, %loops:2 = transform.structured.fuse %unary {tile_sizes = [4, 4], tile_interchange = [0, 1]}
       : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
 
     %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.op<"func.func">

--- a/test/Dialect/structured_fuse.mlir
+++ b/test/Dialect/structured_fuse.mlir
@@ -1,0 +1,64 @@
+// RUN: tcp-opt -transform-interpreter -canonicalize -cse %s | FileCheck %s
+
+// CHECK: func.func @fuse2(%[[ARG0:.+]]: tensor<40x40xf32>) -> tensor<32x16xf32> {
+// CHECK:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK:   %[[C2:.+]] = arith.constant 2 : index
+// CHECK:   %[[C1:.+]] = arith.constant 1 : index
+// CHECK:   %[[C5:.+]] = arith.constant 5 : index
+// CHECK:   %[[C3:.+]] = arith.constant 3 : index
+// CHECK:   %[[C16:.+]] = arith.constant 16 : index
+// CHECK:   %[[C32:.+]] = arith.constant 32 : index
+// CHECK:   %[[VAL0:.+]] = tensor.empty() : tensor<32x16xf32>
+// CHECK:   %[[VAL1:.+]] = scf.for %arg1 = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%arg2 = %[[VAL0]]) -> (tensor<32x16xf32>) {
+// CHECK:     %[[VAL2:.+]] = scf.for %arg3 = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%arg4 = %arg2) -> (tensor<32x16xf32>) {
+// CHECK:       %[[VAL3:.+]] = arith.addi %arg1, %[[C3]] : index
+// CHECK:       %[[MUL1:.+]] = arith.muli %arg3, %[[C2]] : index
+// CHECK:       %[[VAL4:.+]] = arith.addi %[[MUL1]], %[[C5]] : index
+// CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[VAL3]], %[[VAL4]]] [1, 1] [1, 1] : tensor<40x40xf32> to tensor<1x1xf32>
+// CHECK:       %[[VAL5:.+]] = tensor.empty() : tensor<1x1xf32>
+// CHECK:       %[[VAL6:.+]] = linalg.elemwise_binary ins(%[[SLICE0]], %[[SLICE0]] : tensor<1x1xf32>, tensor<1x1xf32>) outs(%[[VAL5]] : tensor<1x1xf32>) -> tensor<1x1xf32>
+// CHECK:       %[[SLICE1:.+]] = tensor.extract_slice %arg4[%arg1, %arg3] [1, 1] [1, 1] : tensor<32x16xf32> to tensor<1x1xf32>
+// CHECK:       %[[UNARY:.+]] = linalg.elemwise_unary ins(%[[VAL6]] : tensor<1x1xf32>) outs(%[[SLICE1]] : tensor<1x1xf32>) -> tensor<1x1xf32>
+// CHECK:       %[[ISLICE:.+]] = tensor.insert_slice %[[UNARY]] into %arg4[%arg1, %arg3] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<32x16xf32>
+// CHECK:       scf.yield %[[ISLICE]] : tensor<32x16xf32>
+// CHECK:     }
+// CHECK:     scf.yield %[[VAL2]] : tensor<32x16xf32>
+// CHECK:   }
+// CHECK:   return %[[VAL1]] : tensor<32x16xf32>
+func.func @fuse2(%arg0: tensor<40x40xf32>) -> tensor<32x16xf32> {
+    %shape40 = tensor.empty() : tensor<40x40xf32>
+
+    %0 = linalg.elemwise_binary ins(%arg0, %arg0 : tensor<40x40xf32>, tensor<40x40xf32>)
+                             outs(%shape40: tensor<40x40xf32>) -> tensor<40x40xf32>
+
+    %c32 = arith.constant 32 : index
+    %c16 = arith.constant 16 : index
+    %c3 = arith.constant 3 : index
+    %c5 = arith.constant 5 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %slice = tcp.slice %0 starts ( %c3, %c5 ) sizes ( %c32, %c16 ) strides ( %c1, %c2 ) : tensor<40x40xf32> -> tensor<32x16xf32>
+
+    %shape = tensor.empty() : tensor<32x16xf32>
+    %ret = linalg.elemwise_unary ins(%slice: tensor<32x16xf32>) outs(%shape: tensor<32x16xf32>) -> tensor<32x16xf32>
+
+    return %ret : tensor<32x16xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %slice = transform.structured.match ops{["tcp.slice"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %unary = transform.structured.match ops{["linalg.elemwise_unary"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+
+    %1, %loops:2 = transform.structured.fuse %unary {tile_sizes = [1, 1], tile_interchange = [0, 1]}
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.op<"func.func">
+    transform.apply_patterns to %func_op {
+      transform.apply_patterns.tensor.fold_tensor_empty
+      transform.apply_patterns.tensor.fold_tensor_subset_ops
+    } : !transform.op<"func.func">
+
+    transform.yield
+  }
+}

--- a/test/Dialect/structured_fuse.mlir
+++ b/test/Dialect/structured_fuse.mlir
@@ -1,6 +1,6 @@
-// RUN: tcp-opt -transform-interpreter -canonicalize -cse %s | FileCheck %s
+// RUN: tcp-opt --split-input-file -transform-interpreter -canonicalize -cse %s | FileCheck %s
 
-// CHECK: func.func @fuse2(%[[ARG0:.+]]: tensor<40x40xf32>) -> tensor<32x32xf32> {
+// CHECK: func.func @fuse_tcp_slice(%[[ARG0:.+]]: tensor<40x40xf32>) -> tensor<32x32xf32> {
 // CHECK:   %[[C0:.+]] = arith.constant 0 : index
 // CHECK:   %[[C1:.+]] = arith.constant 1 : index
 // CHECK:   %[[C5:.+]] = arith.constant 5 : index
@@ -23,7 +23,7 @@
 // CHECK:     scf.yield %[[VAL2]] : tensor<32x32xf32>
 // CHECK:   }
 // CHECK:   return %[[VAL1]] : tensor<32x32xf32>
-func.func @fuse2(%arg0: tensor<40x40xf32>) -> tensor<32x32xf32> {
+func.func @fuse_tcp_slice(%arg0: tensor<40x40xf32>) -> tensor<32x32xf32> {
     %shape40 = tensor.empty() : tensor<40x40xf32>
 
     %0 = linalg.elemwise_binary ins(%arg0, %arg0 : tensor<40x40xf32>, tensor<40x40xf32>)
@@ -40,6 +40,72 @@ func.func @fuse2(%arg0: tensor<40x40xf32>) -> tensor<32x32xf32> {
     %ret = linalg.elemwise_unary ins(%slice: tensor<32x32xf32>) outs(%shape: tensor<32x32xf32>) -> tensor<32x32xf32>
 
     return %ret : tensor<32x32xf32>
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) {
+    %slice = transform.structured.match ops{["tcp.slice"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+    %unary = transform.structured.match ops{["linalg.elemwise_unary"]} in %arg0 : (!transform.any_op) -> !transform.any_op
+
+    %1, %loops:2 = transform.structured.fuse %unary {tile_sizes = [1, 1], tile_interchange = [0, 1]}
+      : (!transform.any_op) -> (!transform.any_op, !transform.any_op, !transform.any_op)
+
+    %func_op = transform.structured.match ops{["func.func"]} in %arg0 : (!transform.any_op) -> !transform.op<"func.func">
+    transform.apply_patterns to %func_op {
+      transform.apply_patterns.tensor.fold_tensor_empty
+      transform.apply_patterns.tensor.fold_tensor_subset_ops
+    } : !transform.op<"func.func">
+
+    transform.yield
+  }
+}
+
+// -----
+
+// CHECK: func.func @fuse_tcp_slice_stride2(%[[ARG0:.+]]: tensor<40x40xf32>) -> tensor<32x16xf32> {
+// CHECK:   %[[C0:.+]] = arith.constant 0 : index
+// CHECK:   %[[C2:.+]] = arith.constant 2 : index
+// CHECK:   %[[C1:.+]] = arith.constant 1 : index
+// CHECK:   %[[C5:.+]] = arith.constant 5 : index
+// CHECK:   %[[C3:.+]] = arith.constant 3 : index
+// CHECK:   %[[C16:.+]] = arith.constant 16 : index
+// CHECK:   %[[C32:.+]] = arith.constant 32 : index
+// CHECK:   %[[VAL0:.+]] = tensor.empty() : tensor<32x16xf32>
+// CHECK:   %[[VAL1:.+]] = scf.for %arg1 = %[[C0]] to %[[C32]] step %[[C1]] iter_args(%arg2 = %[[VAL0]]) -> (tensor<32x16xf32>) {
+// CHECK:     %[[VAL2:.+]] = scf.for %arg3 = %[[C0]] to %[[C16]] step %[[C1]] iter_args(%arg4 = %arg2) -> (tensor<32x16xf32>) {
+// CHECK:       %[[VAL3:.+]] = arith.addi %arg1, %[[C3]] : index
+// CHECK:       %[[MUL1:.+]] = arith.muli %arg3, %[[C2]] : index
+// CHECK:       %[[VAL4:.+]] = arith.addi %[[MUL1]], %[[C5]] : index
+// CHECK:       %[[SLICE0:.+]] = tensor.extract_slice %[[ARG0]][%[[VAL3]], %[[VAL4]]] [1, 2] [1, 1] : tensor<40x40xf32> to tensor<1x2xf32>
+// CHECK:       %[[VAL5:.+]] = tensor.empty() : tensor<1x2xf32>
+// CHECK:       %[[VAL6:.+]] = linalg.elemwise_binary ins(%[[SLICE0]], %[[SLICE0]] : tensor<1x2xf32>, tensor<1x2xf32>) outs(%[[VAL5]] : tensor<1x2xf32>) -> tensor<1x2xf32>
+// CHECK:       %[[SLICE1:.+]] = tcp.slice %[[VAL6]] starts(%[[C0]], %[[C0]]) sizes(%[[C1]], %[[C1]]) strides(%[[C1]], %[[C2]]) : tensor<1x2xf32> -> tensor<1x1xf32>
+// CHECK:       %[[SLICE2:.+]] = tensor.extract_slice %arg4[%arg1, %arg3] [1, 1] [1, 1] : tensor<32x16xf32> to tensor<1x1xf32>
+// CHECK:       %[[UNARY:.+]] = linalg.elemwise_unary ins(%[[SLICE1]] : tensor<1x1xf32>) outs(%[[SLICE2]] : tensor<1x1xf32>) -> tensor<1x1xf32>
+// CHECK:       %[[ISLICE:.+]] = tensor.insert_slice %[[UNARY]] into %arg4[%arg1, %arg3] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<32x16xf32>
+// CHECK:       scf.yield %[[ISLICE]] : tensor<32x16xf32>
+// CHECK:     }
+// CHECK:     scf.yield %[[VAL2]] : tensor<32x16xf32>
+// CHECK:   }
+// CHECK:   return %[[VAL1]] : tensor<32x16xf32>
+func.func @fuse_tcp_slice_stride2(%arg0: tensor<40x40xf32>) -> tensor<32x16xf32> {
+    %shape40 = tensor.empty() : tensor<40x40xf32>
+
+    %0 = linalg.elemwise_binary ins(%arg0, %arg0 : tensor<40x40xf32>, tensor<40x40xf32>)
+                             outs(%shape40: tensor<40x40xf32>) -> tensor<40x40xf32>
+
+    %c32 = arith.constant 32 : index
+    %c16 = arith.constant 16 : index
+    %c3 = arith.constant 3 : index
+    %c5 = arith.constant 5 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %slice = tcp.slice %0 starts ( %c3, %c5 ) sizes ( %c32, %c16 ) strides ( %c1, %c2 ) : tensor<40x40xf32> -> tensor<32x16xf32>
+
+    %shape = tensor.empty() : tensor<32x16xf32>
+    %ret = linalg.elemwise_unary ins(%slice: tensor<32x16xf32>) outs(%shape: tensor<32x16xf32>) -> tensor<32x16xf32>
+
+    return %ret : tensor<32x16xf32>
 }
 
 module attributes {transform.with_named_sequence} {


### PR DESCRIPTION
This PR adds an implementation of `TilingInterface` for the `tcp.slice` op. This is necessary to enable tile and fuse with `tcp.slice`.
