### PR TITLE
Handle `tcp.bind_symbolic_shape` ops in fusion algorithm

### DIFF
--- a/lib/Dialect/Transforms/FusionPatterns.cpp
+++ b/lib/Dialect/Transforms/FusionPatterns.cpp
@@ -65,7 +65,7 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
       uses.push_back(use.getOwner());
   }
 
-  // All its uses are tcp.bind_symbolic_shpae ops.
+  // All its uses are tcp.bind_symbolic_shape ops.
   if (uses.empty())
     return failure();
 

--- a/lib/Dialect/Transforms/FusionPatterns.cpp
+++ b/lib/Dialect/Transforms/FusionPatterns.cpp
@@ -44,8 +44,15 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
   Region *usesParentRegion = nullptr;
   SmallVector<Operation *> uses;
   llvm::DenseSet<Operation *> usesSet;
+  llvm::DenseSet<tcp::BindSymbolicShapeOp> bindShapeUses;
 
+  LLVM_DEBUG(llvm::dbgs() << "Processing op: " << *op << "\n");
   for (auto &use : op->getUses()) {
+    if (auto bindShapeOp = dyn_cast<tcp::BindSymbolicShapeOp>(use.getOwner())) {
+      bindShapeUses.insert(bindShapeOp);
+      continue;
+    }
+
     auto parentRegion = use.getOwner()->getParentRegion();
     if (usesParentRegion && usesParentRegion != parentRegion)
       return failure();
@@ -57,6 +64,10 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
     if (usesSet.insert(use.getOwner()).second)
       uses.push_back(use.getOwner());
   }
+
+  // All its uses are tcp.bind_symbolic_shpae ops.
+  if (uses.empty())
+    return failure();
 
   // Sorting by dominance ensures that the first element of this vector is
   // the first use of the def. Used below when we want to move the op into
@@ -104,6 +115,9 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
         use->moveBefore(yieldOp);
       }
       op->moveBefore(*uses.begin());
+      for (auto bindShapeOp : bindShapeUses) {
+        bindShapeOp->moveBefore(yieldOp);
+      }
     }
 
     // We then replace all uses of the uses which lie outside the group
@@ -157,6 +171,9 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
     // reordered.
     auto &firstOp = *usesParentRegion->getOps().begin();
     op->moveBefore(&firstOp);
+    for (auto bindShapeOp : bindShapeUses) {
+      bindShapeOp->moveBefore(&firstOp);
+    }
   } else {
     op->emitError("Unhandled case during fusion");
     llvm_unreachable("Unhandled case during fusion");

--- a/lib/Dialect/Transforms/FusionPatterns.cpp
+++ b/lib/Dialect/Transforms/FusionPatterns.cpp
@@ -116,7 +116,7 @@ GenericBottomUpFuser::matchAndRewrite(Operation *op,
       }
       op->moveBefore(*uses.begin());
       for (auto bindShapeOp : bindShapeUses) {
-        bindShapeOp->moveBefore(yieldOp);
+        bindShapeOp->moveAfter(op);
       }
     }
 

--- a/test/Dialect/tcp_fusion.mlir
+++ b/test/Dialect/tcp_fusion.mlir
@@ -132,3 +132,38 @@ func.func @test_fusion_with_symbolic_shape(%arg0 : tensor<?x?xf32>, %arg1 : tens
 
   return %2 : tensor<?x?xf32>
 }
+
+// -----
+
+// CHECK:   func.func @test_multi_use_fusion_with_sym_shapes(%[[ARG0:.+]]: tensor<?x?xf32>, %[[ARG1:.+]]: tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+// CHECK:     %[[V0:.+]] = tcp.symbolic_int "s0" {min_val = 2, max_val = 9223372036854775806} : i64
+// CHECK:     %[[V1:.+]] = tcp.symbolic_int "s1" {min_val = 2, max_val = 9223372036854775806} : i64
+// CHECK:     tcp.bind_symbolic_shape %[[ARG0]], [%[[V0]], %[[V1]]], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+// CHECK:     %[[V2:.+]]:2 = tcp.group {
+// CHECK:       %[[V3:.+]] = tcp.tanh %[[ARG0]] : tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:       tcp.bind_symbolic_shape %[[V3]], [%[[V0]], %[[V1]]], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+// CHECK:       %[[V4:.+]] = tcp.add %[[V3]], %[[V3]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:       tcp.bind_symbolic_shape %[[V4]], [%[[V0]], %[[V1]]], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+// CHECK:       %[[V5:.+]] = tcp.sub %[[V4]], %[[ARG1]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:       %[[V6:.+]] = tcp.mul %[[V4]], %[[V5]] : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+// CHECK:       tcp.yield %[[V5]], %[[V6]] : tensor<?x?xf32>, tensor<?x?xf32>
+// CHECK:     } : tensor<?x?xf32>, tensor<?x?xf32>
+// CHECK:     tcp.bind_symbolic_shape %[[V2]]#0, [%[[V0]], %[[V1]]], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+// CHECK:     tcp.bind_symbolic_shape %[[V2]]#1, [%[[V0]], %[[V1]]], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+// CHECK:     return %[[V2]]#0, %[[V2]]#1 : tensor<?x?xf32>, tensor<?x?xf32>
+// CHECK:   }
+func.func @test_multi_use_fusion_with_sym_shapes(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> (tensor<?x?xf32>, tensor<?x?xf32>)  {
+  %s0 = tcp.symbolic_int "s0" {min_val = 2, max_val = 9223372036854775806} : i64
+  %s1 = tcp.symbolic_int "s1" {min_val = 2, max_val = 9223372036854775806} : i64
+  tcp.bind_symbolic_shape %arg0, [%s0, %s1], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+
+  %0 = tcp.tanh %arg0 : tensor<?x?xf32> -> tensor<?x?xf32>
+  tcp.bind_symbolic_shape %0, [%s0, %s1], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+  %1 = tcp.add %0, %0 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  tcp.bind_symbolic_shape %1, [%s0, %s1], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+  %2 = tcp.sub %1, %arg1 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  tcp.bind_symbolic_shape %2, [%s0, %s1], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+  %3 = tcp.mul %1, %2 : tensor<?x?xf32>, tensor<?x?xf32> -> tensor<?x?xf32>
+  tcp.bind_symbolic_shape %3, [%s0, %s1], affine_map<()[s0, s1] -> (s0, s1)> : tensor<?x?xf32>
+  "func.return" (%2, %3) : (tensor<?x?xf32>, tensor<?x?xf32>) -> ()
+}


### PR DESCRIPTION
The current fusion algorithm does not handle `tcp.bind_symbolic_shape` ops very well because these ops cause an op to have multiple downstream uses. This change handles these ops "specially". We collect all the uses of an op which only specify the shape of the output into a separate use category. We then move the bind shape ops along with the original op if it was moved to another region.