### PR TITLE
update checking logic for scale and zp op

### DIFF
--- a/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
+++ b/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
@@ -154,39 +154,18 @@ public:
     helper.addIntAttr("quant_max", op.getQuantMax());
 
     // scale
-    auto scaleOp = op.getScale().getDefiningOp();
-    if (!scaleOp)
-      return rewriter.notifyMatchFailure(op, "Missing scale operation");
-    auto scaleTensor = dyn_cast<torch::Torch::ValueTensorLiteralOp>(scaleOp);
-    if (!scaleTensor)
-      return rewriter.notifyMatchFailure(
-          op, "Scale operation is not ValueTensorLiteralOp");
-    auto scaleElements =
-        dyn_cast<DenseFPElementsAttr>(scaleTensor.getValueAttr());
-    // scale should be a [1] tensor.
-    if (!scaleElements || scaleElements.getNumElements() != 1)
+    auto scaleTy = adaptor.getScale().dyn_cast<RankedTensorType>();
+    if (!scaleTy || scaleTy.getShape().size() != 1 ||
+        scaleTy.getNumElements() != 1)
       return rewriter.notifyMatchFailure(op, "Unsupported scale type or size");
     helper.addOperand("scale", adaptor.getScale());
 
     // zero_point
-    auto zeroPointOp = op.getZeroPoint().getDefiningOp();
-    if (!zeroPointOp)
-      return rewriter.notifyMatchFailure(op, "Missing zero point operation");
-    if (auto zeroPointTensor =
-            dyn_cast<torch::Torch::ValueTensorLiteralOp>(zeroPointOp)) {
-      auto zeroPointElements =
-          dyn_cast<DenseIntElementsAttr>(zeroPointTensor.getValueAttr());
-      // zero_point should be a [1] tensor.
-      if (!zeroPointElements || zeroPointElements.getNumElements() != 1)
-        return rewriter.notifyMatchFailure(
-            op, "Unsupported zero point type or size");
-    } else if (!dyn_cast<torch::Torch::AtenZerosOp>(zeroPointOp) &&
-               !dyn_cast<torch::Torch::AtenZerosLikeOp>(zeroPointOp)) {
-      // zero like operations are converted through torch-to-tcp
-      return rewriter.notifyMatchFailure(
-          op, "Zero point operation is not ValueTensorLiteralOp or Zero "
-              "operation");
-    }
+    auto zeroPointTy = adaptor.getZeroPoint().dyn_cast<RankedTensorType>();
+    if (!zeroPointTy || zeroPointTy.getShape().size() != 1 ||
+        zeroPointTy.getNumElements() != scaleTy.getNumElements())
+      return rewriter.notifyMatchFailure(op,
+                                         "Unsupported zero point type or size");
     helper.addOperand("zero_point", adaptor.getZeroPoint());
 
     return helper.replace();
@@ -209,40 +188,17 @@ public:
     helper.addIntAttr("quant_max", op.getQuantMax());
 
     // scale
-    auto scaleOp = op.getScale().getDefiningOp();
-    if (!scaleOp)
-      return rewriter.notifyMatchFailure(op, "Missing scale operation");
-    auto scaleTensor = dyn_cast<torch::Torch::ValueTensorLiteralOp>(scaleOp);
-    if (!scaleTensor)
-      return rewriter.notifyMatchFailure(
-          op, "Scale operation is not ValueTensorLiteralOp");
-    auto scaleElements =
-        dyn_cast<DenseFPElementsAttr>(scaleTensor.getValueAttr());
-    // scale should be a [C] tensor.
-    if (!scaleElements || scaleElements.getType().getShape().size() != 1)
+    auto scaleTy = adaptor.getScale().dyn_cast<RankedTensorType>();
+    if (!scaleTy || scaleTy.getShape().size() != 1)
       return rewriter.notifyMatchFailure(op, "Unsupported scale type or size");
     helper.addOperand("scale", adaptor.getScale());
 
     // zero_point
-    auto zeroPointOp = op.getZeroPoint().getDefiningOp();
-    if (!zeroPointOp)
-      return rewriter.notifyMatchFailure(op, "Missing zero point operation");
-    if (auto zeroPointTensor =
-            dyn_cast<torch::Torch::ValueTensorLiteralOp>(zeroPointOp)) {
-      auto zeroPointElements =
-          dyn_cast<DenseIntElementsAttr>(zeroPointTensor.getValueAttr());
-      // zero_point should be a [C] tensor.
-      if (!zeroPointElements ||
-          zeroPointElements.getType().getShape().size() != 1)
-        return rewriter.notifyMatchFailure(
-            op, "Unsupported zero point type or size");
-    } else if (!dyn_cast<torch::Torch::AtenZerosOp>(zeroPointOp) &&
-               !dyn_cast<torch::Torch::AtenZerosLikeOp>(zeroPointOp)) {
-      // zero like operations are converted through torch-to-tcp
-      return rewriter.notifyMatchFailure(
-          op, "Zero point operation is not ValueTensorLiteralOp or Zero "
-              "operation");
-    }
+    auto zeroPointTy = adaptor.getZeroPoint().dyn_cast<RankedTensorType>();
+    if (!zeroPointTy || zeroPointTy.getShape().size() != 1 ||
+        zeroPointTy.getNumElements() != scaleTy.getNumElements())
+      return rewriter.notifyMatchFailure(op,
+                                         "Unsupported zero point type or size");
     helper.addOperand("zero_point", adaptor.getZeroPoint());
 
     return helper.replace();

--- a/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
+++ b/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
@@ -157,6 +157,7 @@ public:
     auto scaleTy = adaptor.getScale().getType().dyn_cast<RankedTensorType>();
     if (!scaleTy || scaleTy.getShape().size() != 1 ||
         scaleTy.getNumElements() != 1)
+      // scale should be a [1] tensor.
       return rewriter.notifyMatchFailure(op, "Unsupported scale type or size");
     helper.addOperand("scale", adaptor.getScale());
 
@@ -165,6 +166,7 @@ public:
         adaptor.getZeroPoint().getType().dyn_cast<RankedTensorType>();
     if (!zeroPointTy || zeroPointTy.getShape().size() != 1 ||
         zeroPointTy.getNumElements() != scaleTy.getNumElements())
+      // zero_point should be a [1] tensor.
       return rewriter.notifyMatchFailure(op,
                                          "Unsupported zero point type or size");
     helper.addOperand("zero_point", adaptor.getZeroPoint());
@@ -191,6 +193,7 @@ public:
     // scale
     auto scaleTy = adaptor.getScale().getType().dyn_cast<RankedTensorType>();
     if (!scaleTy || scaleTy.getShape().size() != 1)
+      // scale should be a [C] tensor.
       return rewriter.notifyMatchFailure(op, "Unsupported scale type or size");
     helper.addOperand("scale", adaptor.getScale());
 
@@ -199,6 +202,7 @@ public:
         adaptor.getZeroPoint().getType().dyn_cast<RankedTensorType>();
     if (!zeroPointTy || zeroPointTy.getShape().size() != 1 ||
         zeroPointTy.getNumElements() != scaleTy.getNumElements())
+      // zero_point should be a [C] tensor.
       return rewriter.notifyMatchFailure(op,
                                          "Unsupported zero point type or size");
     helper.addOperand("zero_point", adaptor.getZeroPoint());

--- a/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
+++ b/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
@@ -154,14 +154,15 @@ public:
     helper.addIntAttr("quant_max", op.getQuantMax());
 
     // scale
-    auto scaleTy = adaptor.getScale().dyn_cast<RankedTensorType>();
+    auto scaleTy = adaptor.getScale().getType().dyn_cast<RankedTensorType>();
     if (!scaleTy || scaleTy.getShape().size() != 1 ||
         scaleTy.getNumElements() != 1)
       return rewriter.notifyMatchFailure(op, "Unsupported scale type or size");
     helper.addOperand("scale", adaptor.getScale());
 
     // zero_point
-    auto zeroPointTy = adaptor.getZeroPoint().dyn_cast<RankedTensorType>();
+    auto zeroPointTy =
+        adaptor.getZeroPoint().getType().dyn_cast<RankedTensorType>();
     if (!zeroPointTy || zeroPointTy.getShape().size() != 1 ||
         zeroPointTy.getNumElements() != scaleTy.getNumElements())
       return rewriter.notifyMatchFailure(op,
@@ -188,13 +189,14 @@ public:
     helper.addIntAttr("quant_max", op.getQuantMax());
 
     // scale
-    auto scaleTy = adaptor.getScale().dyn_cast<RankedTensorType>();
+    auto scaleTy = adaptor.getScale().getType().dyn_cast<RankedTensorType>();
     if (!scaleTy || scaleTy.getShape().size() != 1)
       return rewriter.notifyMatchFailure(op, "Unsupported scale type or size");
     helper.addOperand("scale", adaptor.getScale());
 
     // zero_point
-    auto zeroPointTy = adaptor.getZeroPoint().dyn_cast<RankedTensorType>();
+    auto zeroPointTy =
+        adaptor.getZeroPoint().getType().dyn_cast<RankedTensorType>();
     if (!zeroPointTy || zeroPointTy.getShape().size() != 1 ||
         zeroPointTy.getNumElements() != scaleTy.getNumElements())
       return rewriter.notifyMatchFailure(op,


### PR DESCRIPTION
For fake_quantize_ops, `scale` and `zero_point` operands could be lowered by `TorchToTcp` already, so we need to relax the checking condition here (just need to make sure the type and shape are valid).