### PR TITLE
Add support for customizing const inlining and ops with regions to IsolateGroupOps pass

### DIFF
--- a/include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h
+++ b/include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "mlir-tcp/Dialect/IR/TcpOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include <memory>
@@ -26,6 +27,6 @@ createTcpIsolateGroupOpsPass();
 // as an argument to the isolated group.
 void populateIsolateGroupPatterns(
     RewritePatternSet &patterns,
-    std::function<bool(Operation *)> shouldCopyConstPredicate);
+    std::function<bool(GroupOp, Value)> shouldCopyConstPredicate);
 
 } // namespace mlir::tcp

--- a/include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h
+++ b/include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h
@@ -21,7 +21,7 @@ createTcpIsolateGroupOpsPass();
 
 // `createTcpIsolateGroupOpsPass` will clone all const operations used
 // inside a `tcp.group` into the new `tcp.isolated_group` it creates. If
-// you want to customize this behavior, you can create use this instead to
+// you want to customize this behavior, you can use this instead to
 // pass a predicate function to control when a `const-like` operation
 // should be cloned into the isolated group or whether it should be added
 // as an argument to the isolated group.

--- a/include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h
+++ b/include/mlir-tcp/Dialect/Transforms/IsolateGroupOpsPass.h
@@ -18,4 +18,14 @@ namespace mlir::tcp {
 std::unique_ptr<mlir::OperationPass<mlir::ModuleOp>>
 createTcpIsolateGroupOpsPass();
 
+// `createTcpIsolateGroupOpsPass` will clone all const operations used
+// inside a `tcp.group` into the new `tcp.isolated_group` it creates. If
+// you want to customize this behavior, you can create use this instead to
+// pass a predicate function to control when a `const-like` operation
+// should be cloned into the isolated group or whether it should be added
+// as an argument to the isolated group.
+void populateIsolateGroupPatterns(
+    RewritePatternSet &patterns,
+    std::function<bool(Operation *)> shouldCopyConstPredicate);
+
 } // namespace mlir::tcp

--- a/test/Dialect/tcp_isolate_groups.mlir
+++ b/test/Dialect/tcp_isolate_groups.mlir
@@ -120,3 +120,58 @@ func.func @test_inputs_with_multiple_uses(%arg0 : tensor<5xi32>) -> tensor<5xi32
   }) : () -> tensor<5xi32>
    return %10 : tensor<5xi32>
 }
+
+
+// -----
+
+// isolate tcp.group ops in the presence of nested regions.
+
+// CHECK: #map = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK: module {
+// CHECK:   func.func @forward(%[[ARG0:.+]]: tensor<?x4096xf32>, %[[ARG1:.+]]: tensor<?x4096xf32>, %[[ARG2:.+]]: tensor<?x4096xf32>) -> tensor<?x4096xf32> {
+// CHECK:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK:     %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x4096xf32>
+// CHECK:     %[[V0:.+]] = tcp.isolated_group %[[DIM]], %[[ARG0]], %[[ARG1]] attributes {group_type = "codegen_group"} {
+// CHECK:     ^bb0(%[[ARG3:.+]]: index, %[[ARG4:.+]]: tensor<?x4096xf32>, %[[ARG5:.+]]: tensor<?x4096xf32>):
+// CHECK:       %[[V1:.+]] = tensor.empty(%[[ARG3]]) : tensor<?x4096xf32>
+// CHECK:       %[[V2:.+]] = scf.forall (%[[ARG6:.+]], %[[ARG7:.+]]) in (%[[ARG3]], 4096) shared_outs(%[[ARG8:.+]] = %[[V1]]) -> (tensor<?x4096xf32>) {
+// CHECK:         %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG4]][%[[ARG6]], %[[ARG7]]] [1, 1] [1, 1] : tensor<?x4096xf32> to tensor<1x1xf32>
+// CHECK:         %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG5]][%[[ARG6]], %[[ARG7]]] [1, 1] [1, 1] : tensor<?x4096xf32> to tensor<1x1xf32>
+// CHECK:         %[[V3:.+]] = tensor.empty() : tensor<1x1xf32>
+// CHECK:         %[[V4:.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[EXTRACTED_SLICE]], %[[EXTRACTED_SLICE_0]] : tensor<1x1xf32>, tensor<1x1xf32>) outs(%[[V3]] : tensor<1x1xf32>) {
+// CHECK:         ^bb0(%[[IN:.+]]: f32, %[[IN_1:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:           %[[V5:.+]] = arith.mulf %[[IN]], %[[IN_1]] : f32
+// CHECK:           linalg.yield %[[V5]] : f32
+// CHECK:         } -> tensor<1x1xf32>
+// CHECK:         scf.forall.in_parallel {
+// CHECK:           tensor.parallel_insert_slice %[[V4]] into %[[ARG8]][%[[ARG6]], %[[ARG7]]] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<?x4096xf32>
+// CHECK:         }
+// CHECK:       }
+// CHECK:       tcp.yield %[[V2]] : tensor<?x4096xf32>
+// CHECK:     } : index, tensor<?x4096xf32>, tensor<?x4096xf32> -> tensor<?x4096xf32>
+// CHECK:     return %[[V0]] : tensor<?x4096xf32>
+// CHECK:   }
+// CHECK: }
+#map = affine_map<(d0, d1) -> (d0, d1)>
+func.func @forward(%arg0: tensor<?x4096xf32>, %arg1: tensor<?x4096xf32>, %arg2: tensor<?x4096xf32>) -> tensor<?x4096xf32> {
+  %c0 = arith.constant 0 : index
+  %dim = tensor.dim %arg0, %c0 : tensor<?x4096xf32>
+  %0 = tcp.group attributes {group_type = "codegen_group"} {
+    %1 = tensor.empty(%dim) : tensor<?x4096xf32>
+    %2 = scf.forall (%arg3, %arg4) in (%dim, 4096) shared_outs(%arg5 = %1) -> (tensor<?x4096xf32>) {
+      %extracted_slice = tensor.extract_slice %arg0[%arg3, %arg4] [1, 1] [1, 1] : tensor<?x4096xf32> to tensor<1x1xf32>
+      %extracted_slice_0 = tensor.extract_slice %arg1[%arg3, %arg4] [1, 1] [1, 1] : tensor<?x4096xf32> to tensor<1x1xf32>
+      %3 = tensor.empty() : tensor<1x1xf32>
+      %4 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%extracted_slice, %extracted_slice_0 : tensor<1x1xf32>, tensor<1x1xf32>) outs(%3 : tensor<1x1xf32>) {
+      ^bb0(%in: f32, %in_4: f32, %out: f32):
+        %8 = arith.mulf %in, %in_4 : f32
+        linalg.yield %8 : f32
+      } -> tensor<1x1xf32>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %4 into %arg5[%arg3, %arg4] [1, 1] [1, 1] : tensor<1x1xf32> into tensor<?x4096xf32>
+      }
+    }
+    tcp.yield %2 : tensor<?x4096xf32>
+  } : tensor<?x4096xf32>
+  return %0 : tensor<?x4096xf32>
+}


### PR DESCRIPTION
A few small improvements to the `IsolateGroupOps` pass:
- Provide a hook to customize whether a const like op used in the `tcp.group` will get copied into the group or whether it will be passed in as an input argument. The main pass does always returns true so this is a non-functional change in `mlir-tcp`. 
- The previous version did not handle ops with contained regions and block arguments (such as an `scf.forall` inside the `tcp.group`). We now handle this (see updated lit test).