### PR TITLE
update custom op conversions

### DIFF
--- a/lib/Conversion/TorchToTcp/Misc.cpp
+++ b/lib/Conversion/TorchToTcp/Misc.cpp
@@ -127,11 +127,15 @@ public:
       }
     }
 
+    // fold the broadcast if no axes are found
+    if (axes.size() == 0) {
+      rewriter.replaceOp(op, input);
+      return success();
+    }
     RankedTensorType resultType =
         OpConversionPattern<AtenOpT>::getTypeConverter()
             ->convertType(op->getResult(0).getType())
             .template cast<RankedTensorType>();
-
     auto axesAttr = rewriter.getI64ArrayAttr(axes);
     rewriter.replaceOpWithNewOp<tcp::BroadcastOp>(op, resultType, input,
                                                   resultShape, axesAttr);

--- a/lib/InitAll.cpp
+++ b/lib/InitAll.cpp
@@ -18,10 +18,12 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Dialect.h"
 #include "torch-mlir/Dialect/Torch/IR/TorchDialect.h"
+#include "torch-mlir/Dialect/TorchConversion/IR/TorchConversionDialect.h"
 
 void mlir::tcp::registerAllDialects(mlir::DialectRegistry &registry) {
   registry.insert<tcp::TcpDialect>();
   registry.insert<torch::Torch::TorchDialect>();
+  registry.insert<torch::TorchConversion::TorchConversionDialect>();
   mlir::func::registerInlinerExtension(registry);
   mlir::tcp::registerTilingInterfaceExternalModels(registry);
 }

--- a/test/Conversion/TorchToTcp/tcp_custom_ops.mlir
+++ b/test/Conversion/TorchToTcp/tcp_custom_ops.mlir
@@ -257,6 +257,23 @@ func.func @torch.aten.fake_quantize_per_channel_affine_zero_like(%input: !torch.
 
 // -----
 
+// CHECK-LABEL: func.func @torch.aten.topk(
+// CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,2304],f32>) -> !torch.vtensor<[?,80],f32> {
+// CHECK:          %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,2304],f32> -> tensor<?x2304xf32>
+// CHECK:          %[[CUSTOM:.*]] = tcp.custom_op("torch.aten.topk") %[[T0]] {dim = -1 : i64, k = 80 : i64, largest = true, sorted = true, torch_operand_names = ["self"]} :
+// CHECK-SAME:      tensor<?x2304xf32> -> tensor<?x80xf32>, tensor<?x80xi64>
+// CHECK:          %[[RES:.*]] = torch_c.from_builtin_tensor %[[CUSTOM:.*]] : tensor<?x80xf32> -> !torch.vtensor<[?,80],f32>
+// CHECK:          return %[[RES]] : !torch.vtensor<[?,80],f32>
+func.func @torch.aten.topk(%input: !torch.vtensor<[?,2304],f32>) -> !torch.vtensor<[?,80],f32> {
+  %int-1 = torch.constant.int -1
+  %int80 = torch.constant.int 80
+  %true = torch.constant.bool true
+  %output0, %output1 = torch.aten.topk %input, %int80, %int-1, %true, %true : !torch.vtensor<[?,2304],f32>, !torch.int, !torch.int, !torch.bool, !torch.bool -> !torch.vtensor<[?,80],f32>, !torch.vtensor<[?,80],si64>
+  return %output0 : !torch.vtensor<[?,80],f32>
+}
+
+// -----
+
 // CHECK-LABEL: func.func @torch.aten.sort(
 // CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,2304],f32>) -> !torch.vtensor<[?,2304],f32> {
 // CHECK:          %[[T0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,2304],f32> -> tensor<?x2304xf32>


### PR DESCRIPTION
- Fix a minor issue with broadcast op (fold the broadcast if axes attr is empty)
- Add following ops to tcp.custom_op:
--`aten.sort`
--`aten.cumsum`
--`aten.min.dim`
--`aten.view`(dynamic shape only)
--`aten.topk`


To test:
`bazel test //...` (in docker)