### PR TITLE
support lowering for aten.log1p

### DIFF
--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -21,6 +21,7 @@ AOT_TEST_SUITE = [
     ("tanh", False),
     ("clamp", False),
     ("relu", False),
+    ("log1p", False),
     ("round_even", False),
     ("sqrt_float", False),
     ("sqrt_int", False),

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -263,6 +263,24 @@ def relu_loader() -> TorchLoaderOutput:
     return TorchLoaderOutput(model=Relu(), inputs=(x,), dynamic_shapes=dynamic_shapes)
 
 
+def log1p_loader() -> TorchLoaderOutput:
+    class Log1p(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return torch.log1p(x)
+
+    # Sample inputs
+    x = torch.randn(2, 3)
+
+    # Dynamic dim constraints
+    batch = Dim("batch")
+    dynamic_shapes = {"x": {0: batch}}
+
+    return TorchLoaderOutput(model=Log1p(), inputs=(x,), dynamic_shapes=dynamic_shapes)
+
+
 def round_even_loader() -> TorchLoaderOutput:
     class RoundEven(torch.nn.Module):
         def __init__(self):

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -272,7 +272,7 @@ def log1p_loader() -> TorchLoaderOutput:
             return torch.log1p(x)
 
     # Sample inputs
-    x = torch.randn(2, 3)
+    x = torch.tensor([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
 
     # Dynamic dim constraints
     batch = Dim("batch")

--- a/test/Conversion/TorchToTcp/elementwise.mlir
+++ b/test/Conversion/TorchToTcp/elementwise.mlir
@@ -762,3 +762,22 @@ func.func @torch.aten.to.dtype(%arg0: !torch.vtensor<[?,?],i1>) -> !torch.vtenso
   %0 = torch.aten.to.dtype %arg0, %int11, %false, %false, %none : !torch.vtensor<[?,?],i1>, !torch.int, !torch.bool, !torch.bool, !torch.none -> !torch.vtensor<[?,?],ui8>
   return %0 : !torch.vtensor<[?,?],ui8>
 }
+
+// -----
+
+// CHECK-LABEL:  func.func @torch.aten.log1p(
+// CHECK-SAME:         %[[ARG0:.*]]: !torch.vtensor<[?,4,19,2],f32>) -> !torch.vtensor<[?,4,19,2],f32> {
+// CHECK-DAG:     %[[TO_BUILTIN0:.*]] = torch_c.to_builtin_tensor %[[ARG0]] : !torch.vtensor<[?,4,19,2],f32> -> tensor<?x4x19x2xf32>
+// CHECK:         %[[CONST:.*]] =  tcp.const {value = dense<1.000000e+00> : tensor<f32>} : tensor<f32>
+// CHECK:         %[[EXPAND_SHAPE:.*]] = tensor.expand_shape %[[CONST]] [] output_shape [1, 1, 1, 1] : tensor<f32> into tensor<1x1x1x1xf32>
+// CHECK:         %[[CONST0:.*]] = arith.constant 0 : index
+// CHECK:         %[[DIM0:.*]] = tensor.dim %[[TO_BUILTIN0]], %[[CONST0]] : tensor<?x4x19x2xf32>
+// CHECK:         %[[BROADCAST:.*]] = tcp.broadcast %[[EXPAND_SHAPE]], %[[DIM0]]
+// CHECK:         %[[ADD:.*]] = tcp.add %[[TO_BUILTIN0]], %[[BROADCAST]] : tensor<?x4x19x2xf32>, tensor<?x4x19x2xf32> -> tensor<?x4x19x2xf32>
+// CHECK:         %[[LOG:.*]] = tcp.log %[[ADD]] : tensor<?x4x19x2xf32> -> tensor<?x4x19x2xf32>
+// CHECK:         %[[FROM_BUILTIN:.*]] = torch_c.from_builtin_tensor %[[LOG]] : tensor<?x4x19x2xf32> -> !torch.vtensor<[?,4,19,2],f32>
+// CHECK:         return %[[FROM_BUILTIN]] : !torch.vtensor<[?,4,19,2],f32>
+func.func @torch.aten.log1p(%arg0: !torch.vtensor<[?,4,19,2],f32>) -> !torch.vtensor<[?,4,19,2],f32> {
+  %1 = torch.aten.log1p %arg0 : !torch.vtensor<[?,4,19,2],f32> -> !torch.vtensor<[?,4,19,2],f32>
+  return %1 : !torch.vtensor<[?,4,19,2],f32>
+}


### PR DESCRIPTION
Lower aten.log1p op to  tcp.log(tcp.add(input, 1.0))

To test:

`bazel test //...` (in docker)