### PR TITLE
relax aten.view conversion constraint 

### DIFF
--- a/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
+++ b/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
@@ -299,14 +299,11 @@ public:
     torch_to_tcp::TorchToTcpCustomOpConversionHelper helper{op, rewriter,
                                                             getTypeConverter()};
     Value self = adaptor.getSelf();
-    auto srcType = self.getType().cast<RankedTensorType>();
-    auto resultType =
-        getTypeConverter()->convertType(op.getType()).cast<RankedTensorType>();
-
     SmallVector<int64_t> size;
     // static size array will be handled through TOSA dialect
     if (matchPattern(op.getSize(), m_TorchListOfConstantInts(size)))
-      return rewriter.notifyMatchFailure(op, "only dynamic shape is supported");
+      return rewriter.notifyMatchFailure(op,
+                                         "only non-constant size is supported");
 
     helper.addOperand("self", self);
     Operation *primListOp = op.getSize().getDefiningOp();

--- a/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
+++ b/lib/Conversion/TorchToTcp/TcpCustomOp.cpp
@@ -304,9 +304,8 @@ public:
         getTypeConverter()->convertType(op.getType()).cast<RankedTensorType>();
 
     SmallVector<int64_t> size;
-    // static shape will be handled through TOSA dialect
-    if (matchPattern(op.getSize(), m_TorchListOfConstantInts(size)) &&
-        srcType.hasStaticShape() && resultType.hasStaticShape())
+    // static size array will be handled through TOSA dialect
+    if (matchPattern(op.getSize(), m_TorchListOfConstantInts(size)))
       return rewriter.notifyMatchFailure(op, "only dynamic shape is supported");
 
     helper.addOperand("self", self);


### PR DESCRIPTION
Only convert aten.view to tcp.custom_op when the `size` array is non-constant. The rest will be handled through torch-to-tosa.

TODO: send out an upstream PR to fix` tosa.reshape`  size calculation logic.