### PR TITLE
[WORK IN PROGRESS] tcp.scatter and tcp.scatter_nd

### DIFF
--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -664,7 +664,7 @@ def Tcp_GatherOp : Tcp_Op<"gather", [Pure, AllElementTypesMatch<["input", "out"]
 
 def Tcp_GatherNDOp : Tcp_Op<"gather_nd", [Pure, AllElementTypesMatch<["input", "out"]>]> {
 
-  let summary = "Gather elements from input based on indices over numtiple dimentions";
+  let summary = "Gather elements from input based on indices over multiple dimentions";
 
   let description = [{
     Gathers elements from a given tensor based on indices that index along multiple dimensions.

--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -686,6 +686,32 @@ def Tcp_GatherNDOp : Tcp_Op<"gather_nd", [Pure, AllElementTypesMatch<["input", "
   let hasVerifier = 1;
 }
 
+def Tcp_ScatterNDOp : Tcp_Op<"scatter_nd", [Pure,  AllElementTypesMatch<["input", "values", "out"]>]> {
+  
+let summary = "Scatter elements from values over the input based on indices over multiple dimensions";
+
+  let description = [{
+    Scatter elements from the values tensor over the input tensor according to the indcies tensor 
+    along multiple dimensions.
+  
+    ___TODO___add: More details regarding this op: docs/gather.md
+  }];
+
+  let arguments = (ins
+    Tcp_Tensor:$input,
+    Tcp_IntTensor:$indices,
+    Tcp_Tensor:$values
+  );
+  
+  let results = (outs
+    Tcp_Tensor:$out
+  );
+
+  let assemblyFormat = "$input `,` $indices `,` $values attr-dict `:` type($input) `,` type($indices) `,` type($values) `->` type($out)";
+
+  let hasVerifier = 1;
+}
+
 def Tcp_SliceOp : Tcp_Op<"slice", [Pure, AllElementTypesMatch<["in", "out"]>, SameVariadicOperandSize]> {
 
   let summary = "Extracts a slice of the input tensor";

--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -662,6 +662,30 @@ def Tcp_GatherOp : Tcp_Op<"gather", [Pure, AllElementTypesMatch<["input", "out"]
   let hasVerifier = 1;
 }
 
+def Tcp_GatherNDOp : Tcp_Op<"gather_nd", [Pure, AllElementTypesMatch<["input", "out"]>]> {
+
+  let summary = "Gather elements from input based on indices over numtiple dimentions";
+
+  let description = [{
+    Gathers elements from a given tensor based on indices that index along multiple dimensions.
+
+    More details regarding this op: docs/gather.md
+  }];
+
+  let arguments = (ins
+    Tcp_Tensor:$input,
+    Tcp_IntTensor:$indices
+  );
+
+  let results = (outs
+    Tcp_Tensor:$out
+  );
+
+  let assemblyFormat = "$input `,` $indices attr-dict `:` type($input) `,` type($indices) `->` type($out)";
+
+  let hasVerifier = 1;
+}
+
 def Tcp_SliceOp : Tcp_Op<"slice", [Pure, AllElementTypesMatch<["in", "out"]>, SameVariadicOperandSize]> {
 
   let summary = "Extracts a slice of the input tensor";

--- a/include/mlir-tcp/Dialect/IR/TcpOps.td
+++ b/include/mlir-tcp/Dialect/IR/TcpOps.td
@@ -686,6 +686,33 @@ def Tcp_GatherNDOp : Tcp_Op<"gather_nd", [Pure, AllElementTypesMatch<["input", "
   let hasVerifier = 1;
 }
 
+def Tcp_ScatterOp : Tcp_Op<"scatter", [Pure,  AllElementTypesMatch<["input", "values", "out"]>]> {
+
+ let summary = "Scatter elements from values into input based on indices";
+
+  let description = [{
+    Scatter elements from values into the input tensortensor based on indices that index along a given dim.
+
+    The indexing of scatter is similar to gather, which is documented in docs/gather.md
+  }];
+
+  let arguments = (ins
+    Tcp_Tensor:$input,
+    Tcp_IntTensor:$indices,
+    Tcp_Tensor:$values,
+    IndexAttr:$dim
+  );
+
+  let results = (outs
+    Tcp_Tensor:$out
+  );
+
+  let assemblyFormat = "$input `,` $indices `,` $values `,` attr-dict `:` type($input) `,` type($indices) `,` type($values) `->` type($out)";
+
+  let hasVerifier = 1;
+
+}
+
 def Tcp_ScatterNDOp : Tcp_Op<"scatter_nd", [Pure,  AllElementTypesMatch<["input", "values", "out"]>]> {
   
 let summary = "Scatter elements from values over the input based on indices over multiple dimensions";
@@ -694,7 +721,7 @@ let summary = "Scatter elements from values over the input based on indices over
     Scatter elements from the values tensor over the input tensor according to the indcies tensor 
     along multiple dimensions.
   
-    ___TODO___add: More details regarding this op: docs/gather.md
+    Note: the shape of the indicies is similar to that of gather documented in docs/gather.md
   }];
 
   let arguments = (ins

--- a/lib/Conversion/TcpToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TcpToLinalg/DataMovement.cpp
@@ -186,6 +186,7 @@ public:
   }
 };
 
+
 class ConvertScatterNDOp : public OpConversionPattern<ScatterNDOp> {
 public:
   using OpConversionPattern::OpConversionPattern;
@@ -193,13 +194,21 @@ public:
     LogicalResult
   matchAndRewrite(ScatterNDOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
 
+
+
+
+    // auto generic = rewriter.create<linalg::GenericOp>(
+    //   loc, op.getType(), 
+    // );
   
                     assert(false);
     return failure();
   }
 
 };
+
 
 } // namespace
 
@@ -212,6 +221,6 @@ void mlir::TcpToLinalg::populateDataMovementPatternsAndLegality(
   patterns.add<ConvertGatherOp>(typeConverter, context);
   target.addIllegalOp<GatherNDOp>();
   patterns.add<ConvertGatherNDOp>(typeConverter, context);
-  target.addIllegalOp<ScatterNDOp>();
-  patterns.add<ConvertScatterNDOp>(typeConverter, context);
+  // target.addIllegalOp<ScatterNDOp>();
+  // patterns.add<ConvertScatterNDOp>(typeConverter, context);
 }

--- a/lib/Conversion/TcpToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TcpToLinalg/DataMovement.cpp
@@ -186,6 +186,21 @@ public:
   }
 };
 
+class ConvertScatterNDOp : public OpConversionPattern<ScatterNDOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+    LogicalResult
+  matchAndRewrite(ScatterNDOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+  
+                    assert(false);
+    return failure();
+  }
+
+};
+
 } // namespace
 
 void mlir::TcpToLinalg::populateDataMovementPatternsAndLegality(
@@ -197,4 +212,6 @@ void mlir::TcpToLinalg::populateDataMovementPatternsAndLegality(
   patterns.add<ConvertGatherOp>(typeConverter, context);
   target.addIllegalOp<GatherNDOp>();
   patterns.add<ConvertGatherNDOp>(typeConverter, context);
+  target.addIllegalOp<ScatterNDOp>();
+  patterns.add<ConvertScatterNDOp>(typeConverter, context);
 }

--- a/lib/Conversion/TcpToLinalg/DataMovement.cpp
+++ b/lib/Conversion/TcpToLinalg/DataMovement.cpp
@@ -187,29 +187,6 @@ public:
 };
 
 
-class ConvertScatterNDOp : public OpConversionPattern<ScatterNDOp> {
-public:
-  using OpConversionPattern::OpConversionPattern;
-
-    LogicalResult
-  matchAndRewrite(ScatterNDOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    Location loc = op.getLoc();
-
-
-
-
-    // auto generic = rewriter.create<linalg::GenericOp>(
-    //   loc, op.getType(), 
-    // );
-  
-                    assert(false);
-    return failure();
-  }
-
-};
-
-
 } // namespace
 
 void mlir::TcpToLinalg::populateDataMovementPatternsAndLegality(
@@ -221,6 +198,4 @@ void mlir::TcpToLinalg::populateDataMovementPatternsAndLegality(
   patterns.add<ConvertGatherOp>(typeConverter, context);
   target.addIllegalOp<GatherNDOp>();
   patterns.add<ConvertGatherNDOp>(typeConverter, context);
-  // target.addIllegalOp<ScatterNDOp>();
-  // patterns.add<ConvertScatterNDOp>(typeConverter, context);
 }

--- a/lib/Conversion/TcpToTensor/TcpToTensor.cpp
+++ b/lib/Conversion/TcpToTensor/TcpToTensor.cpp
@@ -47,12 +47,42 @@ public:
   }
 };
 
+/**
+ * TODO: the tensor.scatter is still not lowering to anything after this....
+ */
+class ConvertScatterNDOp : public OpConversionPattern<ScatterNDOp> {
+public:
+  using OpConversionPattern::OpConversionPattern;
+
+    LogicalResult
+  matchAndRewrite(ScatterNDOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    Value indicesIn = adaptor.getIndices();
+    auto indicesType = cast<RankedTensorType>(indicesIn.getType());
+    auto indices = rewriter.create<arith::IndexCastOp>(op.getLoc(), 
+    RankedTensorType::get(indicesType.getShape(), rewriter.getIndexType()),
+     adaptor.getIndices()).getResult();
+    int numIndices = cast<RankedTensorType>(indicesIn.getType()).getShape().back();
+    SmallVector<int64_t> scatterDims;
+    for(int i = 0; i < numIndices; i++) scatterDims.push_back(i);
+    rewriter.replaceOpWithNewOp<tensor::ScatterOp>(
+      op, op.getType(), adaptor.getValues(), adaptor.getInput(), indices,
+      scatterDims, true
+    );
+    return success();
+  }
+
+};
+
 void populateTcpToTensorPatternsAndLegality(RewritePatternSet &patterns,
                                             ConversionTarget &target) {
   MLIRContext *context = patterns.getContext();
 
   target.addIllegalOp<tcp::SliceOp>();
   patterns.add<SliceOpConverter>(context);
+  target.addIllegalOp<tcp::ScatterNDOp>();
+  patterns.add<ConvertScatterNDOp>(context);
 }
 
 class ConvertTcpToTensor : public ConvertTcpToTensorBase<ConvertTcpToTensor> {
@@ -61,6 +91,7 @@ public:
     MLIRContext *context = &getContext();
     ConversionTarget target(*context);
     target.addLegalDialect<mlir::tensor::TensorDialect>();
+    target.addLegalDialect<mlir::arith::ArithDialect>();
 
     RewritePatternSet patterns(context);
     populateTcpToTensorPatternsAndLegality(patterns, target);

--- a/lib/Conversion/TcpToTensor/TcpToTensor.cpp
+++ b/lib/Conversion/TcpToTensor/TcpToTensor.cpp
@@ -48,7 +48,9 @@ public:
 };
 
 /**
- * TODO: the tensor.scatter is still not lowering to anything after this....
+ * This lowers tcp.scatter_nd to tensor.scatter.
+ * However, tensor.scatter currently does not have anything that it can lower to, so it
+ * then fails to generate code
  */
 class ConvertScatterNDOp : public OpConversionPattern<ScatterNDOp> {
 public:

--- a/lib/Conversion/TorchToTcp/DataMovement.cpp
+++ b/lib/Conversion/TorchToTcp/DataMovement.cpp
@@ -278,6 +278,11 @@ public:
   }
 };
 
+/**
+ * The index.Tensor_hacked_twin takes a list of tensors which have to be
+ * broadcast together to be the same shape, and then those are feed into a
+ * gather which will select the different axes
+ */
 class ConvertAtenIndexTensorHackedTwin
     : public OpConversionPattern<AtenIndexTensorHackedTwinOp> {
   using OpConversionPattern::OpConversionPattern;
@@ -285,68 +290,51 @@ class ConvertAtenIndexTensorHackedTwin
   LogicalResult
   matchAndRewrite(AtenIndexTensorHackedTwinOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    // ------- Matching the OP -------
     auto self = adaptor.getSelf();
-    auto selfType = cast<RankedTensorType>(self.getType());
     auto indicesList = op.getIndices();
     SmallVector<Value> indices;
     if (!getListConstructElements(indicesList, indices))
       return op.emitError("Failed to match list of indices");
 
-    for (unsigned int i = 0; i < indices.size(); i++) {
-      auto ttype = cast<RankedTensorType>(
-          getTypeConverter()->convertType(indices[i].getType()));
-      if (ttype.getRank() != selfType.getRank() - i) {
-        // Can use tensor.gather instead for this.  But will require that there
-        // are some broadcasting to get the shapes to match what is expected
-        return failure("Failed to rewrite Tensor_hacked_twin.  Need the "
-                       "element gather for this");
-      }
-      for (int j = 1; j < ttype.getRank(); j++) {
-        if (ttype.getShape()[j] != 1)
-          return failure("Expected the axes >=1 to have size 1");
-      }
-    }
-
-    // ------ Rewriting the OP ---------
-
     indices = getTypeConvertedValues(rewriter, op.getLoc(), getTypeConverter(),
                                      indices);
 
-    for (unsigned int i = 0; i < indices.size(); i++) {
-      auto idx = indices[i];
-      auto ttype = cast<RankedTensorType>(idx.getType());
-      auto selfType = cast<RankedTensorType>(self.getType());
-      SmallVector<int64_t> outShape(selfType.getShape());
-      outShape[i] = ttype.getNumElements();
-      auto outType = RankedTensorType::get(
-          outShape, cast<RankedTensorType>(self.getType()).getElementType());
-
-      auto expandedShape = torch_to_tcp::broadcastRankInLeadingDims(
-          rewriter, idx, outShape.size() - ttype.getRank());
-
-      SmallVector<Value> broadcastValues;
-      SmallVector<int64_t> broadcastAxes;
-      for (unsigned int j = 0; j < selfType.getRank(); j++) {
-        if (j != i) {
-          broadcastAxes.push_back(j);
-          broadcastValues.push_back(
-              rewriter.create<tensor::DimOp>(op.getLoc(), self, j));
-        }
-      }
-
-      auto broadcastedShape = rewriter.create<tcp::BroadcastOp>(
-          op.getLoc(), RankedTensorType::get(outShape, ttype.getElementType()),
-          expandedShape, broadcastValues,
-          rewriter.getI64ArrayAttr(broadcastAxes));
-
-      auto gather = rewriter.create<tcp::GatherOp>(op.getLoc(), outType, self,
-                                                   broadcastedShape.getResult(),
-                                                   rewriter.getIndexAttr(i));
-      self = gather.getResult();
+    if (auto indiciesBroadcasted = torch_to_tcp::broadcastManyToMatchShape(
+            rewriter, op.getLoc(), indices)) {
+      indices = indiciesBroadcasted.value();
+    } else {
+      return failure("failed to broadcast the shapes of the input indicies");
     }
 
-    rewriter.replaceOp(op, self);
+    for (int i = 0; i < indices.size(); i++) {
+      indices[i] =
+          torch_to_tcp::broadcastRankInTrailingDims(rewriter, indices[i], 1);
+    }
+
+    auto indicesType = cast<RankedTensorType>(indices[0].getType());
+    int indicesRank = indicesType.getRank();
+    SmallVector<int64_t> outIndexShape;
+    outIndexShape.insert(outIndexShape.begin(), indicesType.getShape().begin(),
+                         indicesType.getShape().end());
+    outIndexShape.back() = indices.size();
+
+    auto outIndexType =
+        RankedTensorType::get(outIndexShape, indicesType.getElementType());
+    auto indexTensor =
+        rewriter
+            .create<tensor::ConcatOp>(
+                op.getLoc(), outIndexType,
+                rewriter.getI64IntegerAttr(indicesRank - 1), indices)
+            .getResult();
+
+    auto outType =
+        cast<RankedTensorType>(getTypeConverter()->convertType(op.getType()));
+
+    auto gatherOp = rewriter.create<tcp::GatherNDOp>(op.getLoc(), outType, self,
+                                                     indexTensor);
+
+    rewriter.replaceOp(op, gatherOp);
+
     return success();
   }
 };

--- a/lib/Conversion/TorchToTcp/DataMovement.cpp
+++ b/lib/Conversion/TorchToTcp/DataMovement.cpp
@@ -351,6 +351,20 @@ class ConvertAtenIndexTensorHackedTwin
   }
 };
 
+class ConvertAtenIndexPutHackedTwin
+: public OpConversionPattern<AtenIndexPutHackedTwinOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+
+   LogicalResult matchAndRewrite(AtenIndexPutHackedTwinOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+      assert(false);
+      return failure();
+    }
+
+};
+
+
 } // namespace
 
 void torch_to_tcp::populateDataMovementPatternsAndLegality(
@@ -370,4 +384,7 @@ void torch_to_tcp::populateDataMovementPatternsAndLegality(
   torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<
       ConvertAtenIndexTensorHackedTwin, AtenIndexTensorHackedTwinOp>(
       typeConverter, patterns, target, convertTorchOpsSet);
+  torch_to_tcp::addPatternIfOpInConvertTorchOpsSet<
+  ConvertAtenIndexPutHackedTwin, AtenIndexPutHackedTwinOp>(
+     typeConverter, patterns, target, convertTorchOpsSet);
 }

--- a/lib/Conversion/TorchToTcp/Utils.cpp
+++ b/lib/Conversion/TorchToTcp/Utils.cpp
@@ -72,6 +72,32 @@ Value broadcastRankInLeadingDims(ConversionPatternRewriter &rewriter,
       input.getDefiningOp()->getLoc(), resultType, input, reassociationMap);
 }
 
+// The parameter input is expected to be of RankedTensorType.
+Value broadcastRankInTrailingDims(ConversionPatternRewriter &rewriter,
+                                  Value input, int64_t rankIncrease) {
+  if (rankIncrease == 0)
+    return input;
+  RankedTensorType inputType = input.getType().cast<RankedTensorType>();
+
+  SmallVector<ReassociationExprs> reassociationMap(inputType.getRank());
+  if (inputType.getRank() > 0) {
+    for (int64_t inputAxis = 0; inputAxis < inputType.getRank(); inputAxis++)
+      reassociationMap[inputAxis].push_back(
+          rewriter.getAffineDimExpr(inputAxis));
+    for (int64_t axis = 0; axis < rankIncrease; axis++)
+      reassociationMap.back().push_back(
+          rewriter.getAffineDimExpr(axis + inputType.getRank()));
+  }
+
+  SmallVector<int64_t> resultShape(inputType.getShape());
+  resultShape.insert(resultShape.end(), rankIncrease, 1);
+  auto resultType =
+      inputType.cloneWith(ArrayRef(resultShape), inputType.getElementType());
+
+  return rewriter.create<tensor::ExpandShapeOp>(
+      input.getDefiningOp()->getLoc(), resultType, input, reassociationMap);
+}
+
 Value broadcastRank0Dor1DToND(ConversionPatternRewriter &rewriter, Value input,
                               int64_t targetRank, int64_t axisInOutput) {
   RankedTensorType inputType = input.getType().cast<RankedTensorType>();
@@ -128,6 +154,98 @@ Value broadcastShapeExceptDims(ConversionPatternRewriter &rewriter, Value input,
   return rewriter.create<tcp::BroadcastOp>(input.getDefiningOp()->getLoc(),
                                            broadcastResultType, input, dimSizes,
                                            axesAttr);
+}
+
+// the parameter values is expected to be an array of RankedTensorType tensors
+std::optional<SmallVector<Value>>
+broadcastManyToMatchShape(ConversionPatternRewriter &rewriter, Location loc,
+                          ValueRange values) {
+  if (values.size() <= 1) {
+    return values;
+  }
+  SmallVector<Value> ret;
+
+  int64_t maxRank = 0;
+  for (auto v : values) {
+    assert(isa<RankedTensorType>(v.getType()) && "assert 1");
+    auto t = cast<RankedTensorType>(v.getType());
+    if (t.getRank() > maxRank)
+      maxRank = t.getRank();
+  }
+
+  for (auto v : values) {
+    auto type = cast<RankedTensorType>(v.getType());
+    v = broadcastRankInLeadingDims(rewriter, v, maxRank - type.getRank());
+    ret.push_back(v);
+  }
+
+  // figure out what the shape should be for each dim
+  struct ShapeInfo {
+    Value value;
+    bool found = false;
+    int64_t static_value = 1;
+  };
+  SmallVector<ShapeInfo> shapes(maxRank);
+
+  for (auto v : ret) {
+    auto t = cast<RankedTensorType>(v.getType());
+    auto shape = t.getShape();
+    for (int64_t i = 0; i < maxRank; i++) {
+      if (shape[i] != 1) {
+        // meaning that this is not something that is already 1, and therefore
+        // would get broadcast
+        if (shapes[i].found) {
+          // then there are multiple inputs which have non-1 values for this
+          // axis we should check that the size is the same.  If there are
+          // different shapes then this would result in an error when
+          // broadcasting
+          if (shape[i] != ShapedType::kDynamic &&
+              shapes[i].static_value != ShapedType::kDynamic &&
+              shapes[i].static_value != shape[i]) {
+            // the broadcast failed as there are two different shapes for this
+            llvm::errs()
+                << "failed with broadcasting, have two different shapes "
+                << shape[i] << " " << shapes[i].static_value << "\n";
+            return {};
+          }
+        } else {
+          shapes[i].found = true;
+          if (shape[i] == ShapedType::kDynamic) {
+            shapes[i].value = rewriter.create<tensor::DimOp>(loc, v, i);
+            shapes[i].static_value = ShapedType::kDynamic;
+          } else {
+            shapes[i].value = rewriter.create<arith::ConstantOp>(
+                loc, rewriter.getIndexAttr(shape[i]));
+            shapes[i].static_value = shape[i];
+          }
+        }
+      }
+    }
+  }
+
+  // do the broadcasts into the shapes
+  for (int64_t i = 0; i < ret.size(); i++) {
+    auto v = ret[i];
+    auto t = cast<RankedTensorType>(v.getType());
+    SmallVector<int64_t> axes;
+    SmallVector<Value> sizes;
+    SmallVector<int64_t> staticShape;
+    for (int64_t j = 0; j < maxRank; j++) {
+      if (t.getShape()[j] == 1 && shapes[j].found) {
+        axes.push_back(j);
+        sizes.push_back(shapes[j].value);
+      }
+      staticShape.push_back(shapes[j].static_value);
+    }
+    if (!axes.empty()) {
+      // there is something to broadcast here, so add the op
+      Type resultType = t.cloneWith(staticShape, t.getElementType());
+      ret[i] = rewriter.create<tcp::BroadcastOp>(
+          loc, resultType, ret[i], sizes, rewriter.getI64ArrayAttr(axes));
+    }
+  }
+
+  return ret;
 }
 
 // The parameters input are expected to be of RankedTensorType.

--- a/lib/Conversion/TorchToTcp/Utils.h
+++ b/lib/Conversion/TorchToTcp/Utils.h
@@ -31,6 +31,11 @@ getTcpSignedness(IntegerType::SignednessSemantics signednessInfo);
 Value broadcastRankInLeadingDims(ConversionPatternRewriter &rewriter,
                                  Value input, int64_t rankIncrease);
 
+// Helper function to expand the rank of the input tensor. Works by
+// adding 1-dim shape to the trailing dims using `tensor::ExpandShapeOp`.
+Value broadcastRankInTrailingDims(ConversionPatternRewriter &rewriter,
+                                  Value input, int64_t rankIncrease);
+
 // Broadcasts the rank of the input tensor from 0D or 1D to ND. If the input
 // tensor is 1D, `axisInOutput` specifies the axis where the input axis should
 // end up in the output.
@@ -48,6 +53,12 @@ Value broadcastShapeExceptDims(ConversionPatternRewriter &rewriter, Value input,
 std::pair<Value, Value>
 broadcastToMatchShape(ConversionPatternRewriter &rewriter, Value lhs,
                       Value rhs);
+
+// Helper function that broadcasts two or more tensors used for indexing to be
+// the same shape If a tensor is 1-dim, then it will be used on its index
+std::optional<SmallVector<Value>>
+broadcastManyToMatchShape(ConversionPatternRewriter &rewriter, Location loc,
+                          ValueRange values);
 
 // Helper function to broadcast a 0D or 1D input tensor to match rank and shape
 // of target. For the 1D case, this projects the input vector to the

--- a/lib/Dialect/IR/TcpOps.cpp
+++ b/lib/Dialect/IR/TcpOps.cpp
@@ -252,6 +252,13 @@ LogicalResult GatherNDOp::verify() {
   return success();
 }
 
+LogicalResult ScatterNDOp::verify() {
+
+  
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // BindSymbolicShapeOp
 //===----------------------------------------------------------------------===//

--- a/test/AotCompile/BUILD
+++ b/test/AotCompile/BUILD
@@ -38,6 +38,7 @@ AOT_TEST_SUITE = [
     ("gather_elements", False),
     ("gather_slices", False),
     ("index_hacked_twin", False),
+    ("slice_write_back", False),
 ]
 
 py_library(

--- a/test/AotCompile/model_loader_lib.py
+++ b/test/AotCompile/model_loader_lib.py
@@ -606,3 +606,21 @@ def index_hacked_twin_loader() -> TorchLoaderOutput:
         model=Model(),
         inputs=(x,),
     )
+
+def slice_write_back_loader() -> TorchLoaderOutput:
+    class Model(torch.nn.Module):
+        def forward(self, x: torch.Tensor, y: torch.Tensor, i1: torch.Tensor, i2: torch.Tensor, i3: torch.Tensor) -> torch.Tensor:
+            x[i1, i2, i3] = y
+            return x
+
+    model = Model()
+    x = torch.rand(10,10,10)
+    y = torch.rand(7)
+    i1 = torch.arange(7)
+    i2 = torch.arange(7) + 1
+    i3 = torch.tensor([0])
+
+    return TorchLoaderOutput(
+        model=model,
+        inputs=(x, y, i1, i2, i3),
+    )

--- a/test/Conversion/TcpToLinalg/data_movement.mlir
+++ b/test/Conversion/TcpToLinalg/data_movement.mlir
@@ -18,3 +18,24 @@ func.func @gather(%arg0 : tensor<1x4x3xf32>, %arg1 : tensor<1x4x2xi64>) -> tenso
   %0 = "tcp.gather"(%arg0, %arg1) {dim = 2 : index} : (tensor<1x4x3xf32>, tensor<1x4x2xi64>) -> tensor<1x4x2xf32>
   return %0 : tensor<1x4x2xf32>
 }
+
+// -----
+
+// CHECK-LABEL: func.func @gatherND
+// CHECK: %[[ret:.+]] = linalg.generic
+// CHECK-DAG: %[[idx0:.+]] = linalg.index 0 : index
+// CHECK-DAG: %[[const0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[gather0:.+]] = tensor.extract %arg1[%[[idx0]], %[[const0]]] : tensor<3x2xi64>
+// CHECK-DAG: %[[gather0cast:.+]] = arith.index_cast %[[gather0]] : i64 to index
+// CHECK-DAG: %[[const1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[gather1:.+]] = tensor.extract %arg1[%[[idx0]], %[[const1]]] : tensor<3x2xi64>
+// CHECK-DAG: %[[gather1cast:.+]] = arith.index_cast %[[gather1]] : i64 to index
+// CHECK-DAG: %[[idx1:.+]] = linalg.index 1 : index
+// CHECK-DAG: %[[idx2:.+]] = linalg.index 2 : index
+// CHECK-DAG: %[[value:.+]] = tensor.extract %arg0[%[[gather0cast]], %[[gather1cast]], %[[idx1]], %[[idx2]]] : tensor<7x11x13x17xf32>
+// CHECK: linalg.yield %[[value]] : f32
+// CHECK: } -> tensor<3x13x17xf32>
+func.func @gatherND(%arg0 : tensor<7x11x13x17xf32>, %arg1 : tensor<3x2xi64>) -> tensor<3x13x17xf32> {
+    %0 = "tcp.gather_nd" (%arg0, %arg1) : (tensor<7x11x13x17xf32>, tensor<3x2xi64>) -> tensor<3x13x17xf32>
+    return %0 : tensor<3x13x17xf32>
+}


### PR DESCRIPTION
This currently includes the tcp.gather_nd PR, so it appears larger than it will be.

There is currently no lowering to linalg for the tcp.scatter/tcp.scatter_nd

More tests are still needed for this

Note: the TosaToSCF.cpp file has an example of tosa.scatter getting lowered to scf, so we could potentially create something similar.